### PR TITLE
fix: can load scene

### DIFF
--- a/Source/DataModels/Components/ComponentMaterial.cpp
+++ b/Source/DataModels/Components/ComponentMaterial.cpp
@@ -24,7 +24,6 @@ ComponentMaterial::ComponentMaterial(bool active, GameObject* owner)
 
 ComponentMaterial::~ComponentMaterial()
 {
-	UnloadTextures();
 }
 
 void ComponentMaterial::Update()

--- a/Source/DataModels/Components/ComponentTransform.cpp
+++ b/Source/DataModels/Components/ComponentTransform.cpp
@@ -95,7 +95,7 @@ void ComponentTransform::LoadOptions(Json& meta)
 	sca.z = (float) meta["localSca_Z"];
 
 	CalculateLocalMatrix();
-	if(!GetOwner()->GetParent()) 
+	if(GetOwner()->GetParent()) 
 		CalculateGlobalMatrix();
 }
 

--- a/Source/DataStructures/Quadtree.cpp
+++ b/Source/DataStructures/Quadtree.cpp
@@ -266,7 +266,7 @@ void Quadtree::RedistributeGameObjects(const GameObject* gameObject)
 	// GameObject redistribution part
 	gameObjects.push_back(gameObject);
 
-	for (std::list<const GameObject*>::iterator it = gameObjects.begin(); it != gameObjects.end();)
+	for (std::list<const GameObject*>::iterator it = std::begin(gameObjects); it != std::end(gameObjects);)
 	{
 		if (*it)
 		{
@@ -285,11 +285,11 @@ void Quadtree::RedistributeGameObjects(const GameObject* gameObject)
 			}
 			else
 			{
-				it = gameObjects.erase(it);
 				if (inFrontRight) frontRightNode->Add(*it);
 				if (inFrontLeft) frontLeftNode->Add(*it);
 				if (inBackRight) backRightNode->Add(*it);
 				if (inBackLeft) backLeftNode->Add(*it);
+				it = gameObjects.erase(it);
 			}
 		}
 	}


### PR DESCRIPTION
Fixed Quadtree, ComponentTransform and removed unnecessary unload in destructor of ComponentMaterial (that for some reason caused a crash, probably because they are deleted after ModuleResources)