### PR TITLE
fix: problems deleting gameobjects with children 

### DIFF
--- a/Source/DataModels/GameObject/GameObject.h
+++ b/Source/DataModels/GameObject/GameObject.h
@@ -34,10 +34,13 @@ public:
 	UID GetUID() const;
 	const char* GetName() const;
 	GameObject* GetParent() const;
+
 	const std::vector<GameObject*> GetChildren() const;
 	void SetChildren(std::vector<std::unique_ptr<GameObject>>& children);
+
 	const std::vector<Component*> GetComponents() const;
 	void SetComponents(std::vector<std::unique_ptr<Component>>& components);
+
 	template <typename T,
 		std::enable_if_t<std::is_base_of<Component, T>::value, bool> = true>
 	const std::vector<T*> GetComponentsByType(ComponentType type) const;
@@ -63,9 +66,10 @@ public:
 	void MoveUpChild(GameObject* childToMove);
 	void MoveDownChild(GameObject* childToMove);
 
+	bool IsADescendant(const GameObject* descendant);
+
 private:
 	bool IsAChild(const GameObject* child);
-	bool IsADescendant(const GameObject* descendant);
 
 private:
 	UID uid;

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -104,18 +104,8 @@ GameObject* Scene::CreateCameraGameObject(const char* name, GameObject* parent)
 
 void Scene::DestroyGameObject(GameObject* gameObject)
 {
+	RemoveFatherAndChildren(gameObject);
 	gameObject->GetParent()->RemoveChild(gameObject);
-	RemoveCamera(gameObject);
-	for (std::vector<GameObject*>::const_iterator it = sceneGameObjects.begin();
-		it != sceneGameObjects.end();
-		++it)
-	{
-		if (*it == gameObject)
-		{
-			sceneGameObjects.erase(it);
-			return;
-		}
-	}
 }
 
 void Scene::ConvertModelIntoGameObject(const char* model)
@@ -176,7 +166,17 @@ GameObject* Scene::SearchGameObjectByID(UID gameObjectID) const
 	return nullptr;
 }
 
-void Scene::RemoveCamera(const GameObject* cameraGameObject)
+void Scene::RemoveFatherAndChildren(const GameObject* father)
+{
+	for (GameObject* child : father->GetChildren())
+	{
+		RemoveFatherAndChildren(child);
+	}
+	RemoveFromCamera(father);
+	RemoveFromScene(father);
+}
+
+void Scene::RemoveFromCamera(const GameObject* cameraGameObject)
 {
 	for (std::vector<GameObject*>::iterator it = sceneCameras.begin();
 		it != sceneCameras.end(); ++it)
@@ -184,6 +184,19 @@ void Scene::RemoveCamera(const GameObject* cameraGameObject)
 		if (cameraGameObject == *it)
 		{
 			sceneCameras.erase(it);
+			return;
+		}
+	}
+}
+
+void Scene::RemoveFromScene(const GameObject* gameObject)
+{
+	for (std::vector<GameObject*>::const_iterator it = sceneGameObjects.begin();
+		it != sceneGameObjects.end(); ++it)
+	{
+		if (*it == gameObject)
+		{
+			sceneGameObjects.erase(it);
 			return;
 		}
 	}

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -172,29 +172,25 @@ void Scene::RemoveFatherAndChildren(const GameObject* father)
 	{
 		RemoveFatherAndChildren(child);
 	}
-	RemoveFromCamera(father);
-	RemoveFromScene(father);
-}
 
-void Scene::RemoveFromCamera(const GameObject* cameraGameObject)
-{
-	for (std::vector<GameObject*>::iterator it = sceneCameras.begin();
-		it != sceneCameras.end(); ++it)
+	Component* component = father->GetComponent(ComponentType::CAMERA);
+	if (component)
 	{
-		if (cameraGameObject == *it)
+		for (std::vector<GameObject*>::iterator it = sceneCameras.begin();
+			it != sceneCameras.end(); ++it)
 		{
-			sceneCameras.erase(it);
-			return;
+			if (father == *it)
+			{
+				sceneCameras.erase(it);
+				return;
+			}
 		}
 	}
-}
 
-void Scene::RemoveFromScene(const GameObject* gameObject)
-{
 	for (std::vector<GameObject*>::const_iterator it = sceneGameObjects.begin();
 		it != sceneGameObjects.end(); ++it)
 	{
-		if (*it == gameObject)
+		if (*it == father)
 		{
 			sceneGameObjects.erase(it);
 			return;

--- a/Source/DataModels/Scene/Scene.h
+++ b/Source/DataModels/Scene/Scene.h
@@ -58,7 +58,9 @@ public:
 	void InitLights();
 
 private:
-	void RemoveCamera(const GameObject* cameraGameObject);
+	void RemoveFatherAndChildren(const GameObject* father);
+	void RemoveFromCamera(const GameObject* cameraGameObject);
+	void RemoveFromScene(const GameObject* gameObject);
 
 	UID uid;
 	std::unique_ptr<GameObject> root;

--- a/Source/DataModels/Scene/Scene.h
+++ b/Source/DataModels/Scene/Scene.h
@@ -59,8 +59,6 @@ public:
 
 private:
 	void RemoveFatherAndChildren(const GameObject* father);
-	void RemoveFromCamera(const GameObject* cameraGameObject);
-	void RemoveFromScene(const GameObject* gameObject);
 
 	UID uid;
 	std::unique_ptr<GameObject> root;

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -112,7 +112,8 @@ void WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
         {
             if (ImGui::MenuItem("Delete"))
             {
-                if (gameObject == App->scene->GetSelectedGameObject())
+                GameObject* selectedGo = App->scene->GetSelectedGameObject();
+                if (gameObject == selectedGo || gameObject->IsADescendant(selectedGo))
                 {
                     App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
                                                                                 // change the focus to its parent

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -208,7 +208,9 @@ update_status ModuleRender::Update()
 	for (const GameObject* gameObject : gameObjectsToDraw)
 	{
 		if (gameObject != nullptr && gameObject->IsActive())
+		{
 			gameObject->Draw();
+		}
 	}
 
 	if(App->debug->IsShowingBoundingBoxes())DrawQuadtree(App->scene->GetLoadedScene()->GetSceneQuadTree());
@@ -345,6 +347,7 @@ void ModuleRender::FillRenderList(const Quadtree* quadtree)
 
 void ModuleRender::AddToRenderList(const GameObject* gameObject)
 {
+	assert(gameObject);
 	ComponentBoundingBoxes* boxes =
 		static_cast<ComponentBoundingBoxes*>(gameObject->GetComponent(ComponentType::BOUNDINGBOX));
 

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -204,7 +204,7 @@ void ModuleScene::SetSceneFromJson(Json& Json)
 	selectedGameObject = loadedScene->GetRoot();
 
 	loadedScene->SetSceneGameObjects(loadedObjects);
-	loadedScene->SetSceneCameras(loadedObjects);
+	loadedScene->SetSceneCameras(loadedCameras);
 	loadedScene->SetAmbientLight(ambientLight);
 	loadedScene->SetDirectionalLight(directionalLight);
 


### PR DESCRIPTION
When creating the scene all gameobjects go to vector sceneCamera provoking that when we search for objects inside camera we take those objects as cameras.

#172 must be approved in order to try this changes out correctly.