### PR TITLE
fix: Throw raycast just when the mouse is pressed

### DIFF
--- a/Source/Modules/ModuleEngineCamera.cpp
+++ b/Source/Modules/ModuleEngineCamera.cpp
@@ -103,7 +103,7 @@ update_status ModuleEngineCamera::Update()
 			}
 
 			// --RAYCAST CALCULATION-- //
-			if (App->input->GetMouseButton(SDL_BUTTON_LEFT) != KeyState::IDLE 
+			if (App->input->GetMouseButton(SDL_BUTTON_LEFT) == KeyState::DOWN
 				&& App->input->GetKey(SDL_SCANCODE_LALT) == KeyState::IDLE)
 			{
 				const WindowScene* windowScene = App->editor->GetScene();


### PR DESCRIPTION
We missed this when we developed the mouse picking, fixed now!

KeyState::DOWN is only true in the first frame that the left click was pressed, the next frames it will be KeyState::REPEAT, so the ray is only thrown when clicking in the Scene, and not when keeping the left click pressed.