### PR TITLE
fix: Guizmo transformations not being applied since last changes in develop

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/WindowScene.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowScene.cpp
@@ -176,17 +176,15 @@ void WindowScene::DrawGuizmo()
 			{
 			case ImGuizmo::OPERATION::TRANSLATE:
 				focusedTransform->SetPosition(postion);
-				App->scene->UpdateGameObjectAndDescendants(focusedTransform->GetOwner());
 				break;
 			case ImGuizmo::OPERATION::ROTATE:
 				focusedTransform->SetRotation(rotation);
-				App->scene->UpdateGameObjectAndDescendants(focusedTransform->GetOwner());
 				break;
 			case ImGuizmo::OPERATION::SCALE:
 				focusedTransform->SetScale(scale);
-				App->scene->UpdateGameObjectAndDescendants(focusedTransform->GetOwner());
 				break;
 			}
+			focusedTransform->UpdateTransformMatrices();
 
 			for (Component* component : focusedObject->GetComponents())
 			{


### PR DESCRIPTION
Solved the problem where transformations where not propertly being applied when modifying the objects with the guizmo