### PR TITLE
refactor: vectors of GameObjects changed to vectors of Components

### DIFF
--- a/Source/DataModels/Components/Component.h
+++ b/Source/DataModels/Components/Component.h
@@ -25,23 +25,18 @@ public:
 	Component(const ComponentType type, const bool active, GameObject* owner, const bool canBeRemoved);
 	virtual ~Component();
 
-	virtual void Init(); // In case any component needs an init to do something once created
-
-	virtual void Update() = 0; // Abstract because each component will perform its own Update
-
-	virtual void Draw();
-
 	virtual void SaveOptions(Json& meta) = 0; // Abstract because each component saves its own values
 	virtual void LoadOptions(Json& meta) = 0; // Abstract because each component loads its own values
 
 	virtual void Enable();
 	virtual void Disable();
 
-	bool GetActive();
-	ComponentType GetType();
+	bool IsActive() const;
+	ComponentType GetType() const;
+	bool IsDrawable() const;
 
-	GameObject* GetOwner();
-	bool GetCanBeRemoved();
+	GameObject* GetOwner() const;
+	bool GetCanBeRemoved() const;
 
 protected:
 	ComponentType type;
@@ -62,10 +57,6 @@ inline Component::~Component()
 {
 }
 
-inline void Component::Init()
-{
-}
-
 inline void Component::Enable()
 {
 	if (type != ComponentType::TRANSFORM)
@@ -82,26 +73,27 @@ inline void Component::Disable()
 	}
 }
 
-inline void Component::Draw()
-{
-}
-
-inline bool Component::GetActive()
+inline bool Component::IsActive() const
 {
 	return active;
 }
 
-inline ComponentType Component::GetType()
+inline ComponentType Component::GetType() const
 {
 	return type;
 }
 
-inline GameObject* Component::GetOwner()
+inline bool Component::IsDrawable() const
+{
+	return this->GetType() == ComponentType::MESHRENDERER || this->GetType() == ComponentType::MATERIAL;
+}
+
+inline GameObject* Component::GetOwner() const
 {
 	return owner;
 }
 
-inline bool Component::GetCanBeRemoved()
+inline bool Component::GetCanBeRemoved() const
 {
 	return canBeRemoved;
 }

--- a/Source/DataModels/Components/ComponentAmbient.h
+++ b/Source/DataModels/Components/ComponentAmbient.h
@@ -14,8 +14,6 @@ public:
 	ComponentAmbient(const float3& color, GameObject* parent);
 	~ComponentAmbient() override;
 
-	void Draw() override {};
-
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;
 };

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -36,27 +36,27 @@ ComponentCamera::~ComponentCamera()
 {
 }
 
-void ComponentCamera::Update()
-{
-	frustum.SetPos((float3) trans->GetGlobalPosition());
+//void ComponentCamera::Update()
+//{
+//	frustum.SetPos((float3) trans->GetGlobalPosition());
+//
+//	float3x3 rotationMatrix = float3x3::FromQuat((Quat)trans->GetGlobalRotation());
+//	frustum.SetFront(rotationMatrix * float3::unitZ);
+//	frustum.SetUp(rotationMatrix * float3::unitY);
+//
+//	if (frustumMode == ECameraFrustumMode::OFFSETFRUSTUM)
+//	{
+//		UpdateFrustumOffset();
+//	}
+//}
 
-	float3x3 rotationMatrix = float3x3::FromQuat((Quat)trans->GetGlobalRotation());
-	frustum.SetFront(rotationMatrix * float3::unitZ);
-	frustum.SetUp(rotationMatrix * float3::unitY);
-
-	if (frustumMode == ECameraFrustumMode::OFFSETFRUSTUM)
-	{
-		UpdateFrustumOffset();
-	}
-}
-
-void ComponentCamera::Draw()
-{
-#ifdef ENGINE
-	if(drawFrustum)
-		App->debug->DrawFrustum(frustum);
-#endif // ENGINE
-}
+//void ComponentCamera::Draw()
+//{
+//#ifdef ENGINE
+//	if(drawFrustum)
+//		App->debug->DrawFrustum(frustum);
+//#endif // ENGINE
+//}
 
 void ComponentCamera::SaveOptions(Json& meta)
 {

--- a/Source/DataModels/Components/ComponentCamera.h
+++ b/Source/DataModels/Components/ComponentCamera.h
@@ -27,8 +27,9 @@ public:
 	ComponentCamera(bool active, GameObject* owner);
 	~ComponentCamera() override;
 
-	void Update() override;
-	void Draw() override;
+	//commented for now
+	//void Update() override;
+	//void Draw() override;
 
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;

--- a/Source/DataModels/Components/ComponentDirLight.cpp
+++ b/Source/DataModels/Components/ComponentDirLight.cpp
@@ -29,39 +29,39 @@ ComponentDirLight::~ComponentDirLight()
 {
 }
 
-void ComponentDirLight::Draw()
-{
-#ifdef ENGINE
-	if (this->GetActive())
-	{
-		ComponentTransform* transform =
-			static_cast<ComponentTransform*>(GetOwner()
-				->GetComponent(ComponentType::TRANSFORM));
-
-		float3 position = transform->GetGlobalPosition();
-		float3 forward = transform->GetGlobalForward();
-
-		float radius = 0.2f;
-
-		for (int i = 0; i < 5; ++i)
-		{
-			float theta = (2.0f * math::pi * float(i)) / 5.0f;
-			float x = radius * math::Cos(theta);
-			float y = radius * math::Sin(theta);
-
-			float3 from = position;
-			from.x += x;
-			from.y += y;
-
-			float3 to = position + forward;
-			to.x += x;
-			to.y += y;
-
-			dd::arrow(from, to, dd::colors::White, 0.05f);
-		}
-	}
-#endif // ENGINE
-}
+//void ComponentDirLight::Draw()
+//{
+//#ifdef ENGINE
+//	if (this->IsActive())
+//	{
+//		ComponentTransform* transform =
+//			static_cast<ComponentTransform*>(GetOwner()
+//				->GetComponent(ComponentType::TRANSFORM));
+//
+//		float3 position = transform->GetGlobalPosition();
+//		float3 forward = transform->GetGlobalForward();
+//
+//		float radius = 0.2f;
+//
+//		for (int i = 0; i < 5; ++i)
+//		{
+//			float theta = (2.0f * math::pi * float(i)) / 5.0f;
+//			float x = radius * math::Cos(theta);
+//			float y = radius * math::Sin(theta);
+//
+//			float3 from = position;
+//			from.x += x;
+//			from.y += y;
+//
+//			float3 to = position + forward;
+//			to.x += x;
+//			to.y += y;
+//
+//			dd::arrow(from, to, dd::colors::White, 0.05f);
+//		}
+//	}
+//#endif // ENGINE
+//}
 
 void ComponentDirLight::SaveOptions(Json& meta)
 {

--- a/Source/DataModels/Components/ComponentDirLight.h
+++ b/Source/DataModels/Components/ComponentDirLight.h
@@ -15,7 +15,8 @@ public:
 	ComponentDirLight(const float3& color, float intensity, GameObject* parent);
 	~ComponentDirLight() override;
 
-	void Draw() override;
+	//commented for now
+	//void Draw() override;
 
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;

--- a/Source/DataModels/Components/ComponentLight.h
+++ b/Source/DataModels/Components/ComponentLight.h
@@ -35,12 +35,8 @@ public:
 
 	virtual ~ComponentLight() override;
 
-	void Update() override;
-
 	void Enable() override;
 	void Disable() override;
-
-	virtual void Draw() override {};
 
 	virtual void SaveOptions(Json& meta) override {};
 	virtual void LoadOptions(Json& meta) override {};
@@ -58,11 +54,6 @@ protected:
 
 	LightType lightType;
 };
-
-inline void ComponentLight::Update()
-{
-	Draw();
-}
 
 inline void ComponentLight::Enable()
 {

--- a/Source/DataModels/Components/ComponentMaterial.cpp
+++ b/Source/DataModels/Components/ComponentMaterial.cpp
@@ -20,15 +20,11 @@
 #endif // ENGINE
 
 ComponentMaterial::ComponentMaterial(bool active, GameObject* owner)
-	: Component(ComponentType::MATERIAL, active, owner, true)
+	: DrawableComponent(ComponentType::MATERIAL, active, owner, true)
 {
 }
 
 ComponentMaterial::~ComponentMaterial()
-{
-}
-
-void ComponentMaterial::Update()
 {
 }
 

--- a/Source/DataModels/Components/ComponentMaterial.h
+++ b/Source/DataModels/Components/ComponentMaterial.h
@@ -1,7 +1,7 @@
 #pragma once
 #pragma warning (disable: 26495)
 
-#include "Components/Component.h"
+#include "Components/DrawableComponent.h"
 
 #include "Math/float3.h"
 
@@ -14,13 +14,11 @@ class ResourceMaterial;
 class ResourceTexture;
 class Json;
 
-class ComponentMaterial : public Component
+class ComponentMaterial : public DrawableComponent
 {
 public:
 	ComponentMaterial(bool active, GameObject* owner);
 	~ComponentMaterial() override;
-
-	void Update() override;
 
 	void Draw() override;
 

--- a/Source/DataModels/Components/ComponentMeshRenderer.cpp
+++ b/Source/DataModels/Components/ComponentMeshRenderer.cpp
@@ -24,7 +24,7 @@
 #endif // ENGINE
 
 ComponentMeshRenderer::ComponentMeshRenderer(const bool active, GameObject* owner)
-	: Component(ComponentType::MESHRENDERER, active, owner, true)
+	: DrawableComponent(ComponentType::MESHRENDERER, active, owner, true)
 {
 }
 
@@ -32,11 +32,6 @@ ComponentMeshRenderer::~ComponentMeshRenderer()
 {
 	if (mesh)
 		mesh->Unload();
-}
-
-void ComponentMeshRenderer::Update()
-{
-
 }
 
 void ComponentMeshRenderer::Draw()

--- a/Source/DataModels/Components/ComponentMeshRenderer.h
+++ b/Source/DataModels/Components/ComponentMeshRenderer.h
@@ -1,23 +1,19 @@
 #pragma once
 
-#include "Components/Component.h"
+#include "Components/DrawableComponent.h"
 
 #include <memory>
-
-#define COMPONENT_MESHRENDERED "MeshRendered"
 
 class ResourceMaterial;
 class ResourceMesh;
 class Json;
 class WindowMeshInput;
 
-class ComponentMeshRenderer : public Component
+class ComponentMeshRenderer : public DrawableComponent
 {
 public:
 	ComponentMeshRenderer(const bool active, GameObject* owner);
 	~ComponentMeshRenderer() override;
-
-	void Update() override;
 
 	void Draw() override;
 	void DrawHighlight();

--- a/Source/DataModels/Components/ComponentPointLight.cpp
+++ b/Source/DataModels/Components/ComponentPointLight.cpp
@@ -1,6 +1,10 @@
 #include "ComponentPointLight.h"
 #include "ComponentTransform.h"
 
+#include "Application.h"
+#include "Modules/ModuleScene.h"
+#include "Scene/Scene.h"
+
 #include "FileSystem/Json.h"
 
 #include "debugdraw.h"
@@ -27,6 +31,9 @@ ComponentPointLight::ComponentPointLight(float radius, const float3& color, floa
 
 ComponentPointLight::~ComponentPointLight()
 {
+	Scene* currentScene = App->scene->GetLoadedScene();
+	currentScene->UpdateScenePointLights();
+	currentScene->RenderPointLights();
 }
 
 void ComponentPointLight::Draw()

--- a/Source/DataModels/Components/ComponentPointLight.cpp
+++ b/Source/DataModels/Components/ComponentPointLight.cpp
@@ -36,21 +36,21 @@ ComponentPointLight::~ComponentPointLight()
 	currentScene->RenderPointLights();
 }
 
-void ComponentPointLight::Draw()
-{
-#ifdef ENGINE
-	if (this->GetActive())
-	{
-		ComponentTransform* transform =
-			static_cast<ComponentTransform*>(GetOwner()
-				->GetComponent(ComponentType::TRANSFORM));
-
-		float3 position = transform->GetGlobalPosition();
-
-		dd::sphere(position, dd::colors::White, radius);
-	}
-#endif // ENGINE
-}
+//void ComponentPointLight::Draw()
+//{
+//#ifdef ENGINE
+//	if (this->IsActive())
+//	{
+//		ComponentTransform* transform =
+//			static_cast<ComponentTransform*>(GetOwner()
+//				->GetComponent(ComponentType::TRANSFORM));
+//
+//		float3 position = transform->GetGlobalPosition();
+//
+//		dd::sphere(position, dd::colors::White, radius);
+//	}
+//#endif // ENGINE
+//}
 
 void ComponentPointLight::SaveOptions(Json& meta)
 {

--- a/Source/DataModels/Components/ComponentPointLight.h
+++ b/Source/DataModels/Components/ComponentPointLight.h
@@ -23,7 +23,8 @@ public:
 
 	~ComponentPointLight() override;
 
-	void Draw() override;
+	//commented for now
+	//void Draw() override;
 
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;

--- a/Source/DataModels/Components/ComponentSpotLight.cpp
+++ b/Source/DataModels/Components/ComponentSpotLight.cpp
@@ -42,23 +42,23 @@ ComponentSpotLight::~ComponentSpotLight()
 	currentScene->RenderSpotLights();
 }
 
-void ComponentSpotLight::Draw()
-{
-#ifdef ENGINE
-	if (this->GetActive())
-	{
-		ComponentTransform* transform =
-			static_cast<ComponentTransform*>(GetOwner()
-				->GetComponent(ComponentType::TRANSFORM));
-
-		float3 position = transform->GetGlobalPosition();
-		float3 forward = transform->GetGlobalForward().Normalized();
-
-		dd::cone(position, forward * radius, dd::colors::White, outerAngle * radius , 0.0f);
-		dd::cone(position, forward * radius, dd::colors::Yellow, innerAngle * radius, 0.0f);
-	}
-#endif // ENGINE
-}
+//void ComponentSpotLight::Draw()
+//{
+//#ifdef ENGINE
+//	if (this->IsActive())
+//	{
+//		ComponentTransform* transform =
+//			static_cast<ComponentTransform*>(GetOwner()
+//				->GetComponent(ComponentType::TRANSFORM));
+//
+//		float3 position = transform->GetGlobalPosition();
+//		float3 forward = transform->GetGlobalForward().Normalized();
+//
+//		dd::cone(position, forward * radius, dd::colors::White, outerAngle * radius , 0.0f);
+//		dd::cone(position, forward * radius, dd::colors::Yellow, innerAngle * radius, 0.0f);
+//	}
+//#endif // ENGINE
+//}
 
 void ComponentSpotLight::SaveOptions(Json& meta)
 {

--- a/Source/DataModels/Components/ComponentSpotLight.cpp
+++ b/Source/DataModels/Components/ComponentSpotLight.cpp
@@ -1,6 +1,10 @@
 #include "ComponentSpotLight.h"
 #include "ComponentTransform.h"
 
+#include "Application.h"
+#include "Modules/ModuleScene.h"
+#include "Scene/Scene.h"
+
 #include "FileSystem/Json.h"
 
 #include "debugdraw.h"
@@ -33,6 +37,9 @@ ComponentSpotLight::ComponentSpotLight(float radius, float innerAngle, float out
 
 ComponentSpotLight::~ComponentSpotLight()
 {
+	Scene* currentScene = App->scene->GetLoadedScene();
+	currentScene->UpdateSceneSpotLights();
+	currentScene->RenderSpotLights();
 }
 
 void ComponentSpotLight::Draw()

--- a/Source/DataModels/Components/ComponentSpotLight.h
+++ b/Source/DataModels/Components/ComponentSpotLight.h
@@ -27,7 +27,8 @@ public:
 
 	~ComponentSpotLight() override;
 
-	void Draw() override;
+	//commented for now
+	//void Draw() override;
 
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;

--- a/Source/DataModels/Components/ComponentTransform.cpp
+++ b/Source/DataModels/Components/ComponentTransform.cpp
@@ -21,11 +21,6 @@ ComponentTransform::~ComponentTransform()
 {
 }
 
-void ComponentTransform::Update()
-{
-	// Empty for now
-}
-
 void ComponentTransform::SaveOptions(Json& meta)
 {
 	meta["type"] = GetNameByType(type).c_str();

--- a/Source/DataModels/Components/ComponentTransform.h
+++ b/Source/DataModels/Components/ComponentTransform.h
@@ -17,8 +17,6 @@ public:
 	ComponentTransform(const bool active, GameObject* owner);
 	~ComponentTransform() override;
 
-	void Update() override;
-
 	void SaveOptions(Json& meta) override;
 	void LoadOptions(Json& meta) override;
 

--- a/Source/DataModels/Components/DrawableComponent.cpp
+++ b/Source/DataModels/Components/DrawableComponent.cpp
@@ -1,0 +1,12 @@
+#include "DrawableComponent.h"
+
+DrawableComponent::DrawableComponent(const ComponentType type,
+									 const bool active,
+									 GameObject* owner,
+									 const bool canBeRemoved) : Component(type, active, owner, canBeRemoved)
+{
+}
+
+DrawableComponent::~DrawableComponent()
+{
+}

--- a/Source/DataModels/Components/DrawableComponent.h
+++ b/Source/DataModels/Components/DrawableComponent.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "DataModels/Components/Component.h"
+
+class DrawableComponent : public Component
+{
+public:
+	DrawableComponent(const ComponentType type, const bool active, GameObject* owner, const bool canBeRemoved);
+	virtual ~DrawableComponent() override;
+
+	//this method should be const, but other Draws seem to have side effects, which shouldn't be the case
+	virtual void Draw() = 0;
+};
+

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -37,41 +37,6 @@ GameObject::GameObject(const char* name, GameObject* parent) : name(name), paren
 
 GameObject::~GameObject()
 {
-	// This should not be here
-	std::vector<ComponentLight*> lights = GetComponentsByType<ComponentLight>(ComponentType::LIGHT);
-	bool hadSpotLight = false, hadPointLight = false;
-	for (ComponentLight* light : lights)
-	{
-		switch (light->GetLightType())
-		{
-		case LightType::SPOT:
-			hadSpotLight = true;
-			break;
-		case LightType::POINT:
-			hadPointLight = true;
-			break;
-		}
-	}
-	//
-
-	components.clear();
-
-	children.clear();
-
-	// This should not be here
-	Scene* currentScene = App->scene->GetLoadedScene();
-
-	if (hadSpotLight)
-	{
-		currentScene->UpdateSceneSpotLights();
-		currentScene->RenderSpotLights();
-	}
-	if (hadPointLight)
-	{
-		currentScene->UpdateScenePointLights();
-		currentScene->RenderPointLights();
-	}
-	//
 }
 
 void GameObject::Update()

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -41,15 +41,6 @@ GameObject::~GameObject()
 
 void GameObject::Update()
 {
-	for (std::unique_ptr<Component>& component : components)
-	{
-		if (component->GetActive())
-		{
-			component->Update();
-		}
-	}
-
-	//if (drawBoundingBoxes) App->debug->DrawBoundingBox(objectOBB);
 }
 
 void GameObject::Draw() const
@@ -60,13 +51,6 @@ void GameObject::Draw() const
 		App->debug->DrawBoundingBox(objectOBB);
 	}
 #endif // ENGINE
-	for (const std::unique_ptr<Component>& component : components)
-	{
-		if (component->GetActive())
-		{
-			component->Draw();
-		}
-	}
 }
 
 void GameObject::DrawSelected()
@@ -86,9 +70,9 @@ void GameObject::DrawSelected()
 		}
 		for (const std::unique_ptr<Component>& component : currentGo->components)
 		{
-			if (component->GetActive())
+			if (component->IsDrawable() && component->IsActive())
 			{
-				component->Draw();
+				static_cast<DrawableComponent*>(component.get())->Draw();
 			}
 		}
 #ifdef ENGINE
@@ -304,11 +288,6 @@ void GameObject::DeactivateChildren()
 {
 	active = false;
 
-	if (children.empty())
-	{
-		return;
-	}
-
 	for (std::unique_ptr<GameObject>& child : children)
 	{
 		child->DeactivateChildren();
@@ -318,11 +297,6 @@ void GameObject::DeactivateChildren()
 void GameObject::ActivateChildren()
 {
 	active = (parent->IsActive() && parent->IsEnabled());
-
-	if (children.empty())
-	{
-		return;
-	}
 
 	for (std::unique_ptr<GameObject>& child : children)
 	{

--- a/Source/DataModels/GameObject/GameObject.h
+++ b/Source/DataModels/GameObject/GameObject.h
@@ -34,6 +34,7 @@ public:
 
 	void Update();
 	void Draw() const;
+	//this most likely shouldn't be here, since it's only needed in ENGINE mode
 	void DrawSelected();
 	void DrawHighlight();
 
@@ -85,9 +86,9 @@ public:
 	const AABB& GetLocalAABB();
 	const AABB& GetEncapsuledAABB();
 	const OBB& GetObjectOBB();
-	const bool isDrawBoundingBoxes() const;
+	const bool IsDrawBoundingBoxes() const;
 
-	void setDrawBoundingBoxes(bool newDraw);
+	void SetDrawBoundingBoxes(bool newDraw);
 	bool IsADescendant(const GameObject* descendant);
 
 private:
@@ -218,12 +219,12 @@ inline const OBB& GameObject::GetObjectOBB()
 	return objectOBB;
 }
 
-inline const bool GameObject::isDrawBoundingBoxes() const
+inline const bool GameObject::IsDrawBoundingBoxes() const
 {
 	return drawBoundingBoxes;
 }
 
-inline void GameObject::setDrawBoundingBoxes(bool newDraw)
+inline void GameObject::SetDrawBoundingBoxes(bool newDraw)
 {
 	drawBoundingBoxes = newDraw;
 }

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -44,16 +44,11 @@ void Scene::FillQuadtree(const std::vector<GameObject*>& gameObjects)
 bool Scene::IsInsideACamera(const OBB& obb) const
 {
 	// TODO: We have to add all the cameras in the future
-	for (GameObject* cameraGameObject : sceneCameras)
+	for (ComponentCamera* camera : sceneCameras)
 	{
-		if (cameraGameObject)
+		if (camera && camera->IsInside(obb))
 		{
-			ComponentCamera* camera =
-				static_cast<ComponentCamera*>(cameraGameObject->GetComponent(ComponentType::CAMERA));
-			if (camera && camera->IsInside(obb))
-			{
-				return true;
-			}
+			return true;
 		}
 	}
 	return false;
@@ -102,8 +97,8 @@ GameObject* Scene::CreateGameObject(const char* name, GameObject* parent)
 GameObject* Scene::CreateCameraGameObject(const char* name, GameObject* parent)
 {
 	GameObject* gameObject = CreateGameObject(name, parent);
-	gameObject->CreateComponent(ComponentType::CAMERA);
-	sceneCameras.push_back(gameObject);
+	Component* camera = gameObject->CreateComponent(ComponentType::CAMERA);
+	sceneCameras.push_back(static_cast<ComponentCamera*>(camera));
 
 	return gameObject;
 }
@@ -177,10 +172,9 @@ void Scene::RemoveFatherAndChildren(const GameObject* father)
 	Component* component = father->GetComponent(ComponentType::CAMERA);
 	if (component)
 	{
-		for (std::vector<GameObject*>::iterator it = sceneCameras.begin();
-			it != sceneCameras.end(); ++it)
+		for (std::vector<ComponentCamera*>::iterator it = std::begin(sceneCameras); it != std::end(sceneCameras); ++it)
 		{
-			if (father == *it)
+			if (father == (*it)->GetOwner())
 			{
 				sceneCameras.erase(it);
 				return;

--- a/Source/DataModels/Scene/Scene.h
+++ b/Source/DataModels/Scene/Scene.h
@@ -7,6 +7,7 @@
 #include "Components/ComponentSpotLight.h"
 
 class GameObject;
+class ComponentCamera;
 class Quadtree;
 
 class Scene
@@ -43,13 +44,13 @@ public:
 	const GameObject* GetDirectionalLight() const;
 	Quadtree * GetSceneQuadTree() const;
 	const std::vector<GameObject*>& GetSceneGameObjects() const;
-	const std::vector<GameObject*>& GetSceneCameras() const;
+	const std::vector<ComponentCamera*>& GetSceneCameras() const;
 	std::unique_ptr<Quadtree> GiveOwnershipOfQuadtree();
 
 	void SetRoot(std::unique_ptr<GameObject> newRoot);
 	void SetSceneQuadTree(std::unique_ptr<Quadtree> quadtree);
 	void SetSceneGameObjects(const std::vector<GameObject*>& gameObjects);
-	void SetSceneCameras(const std::vector<GameObject*>& cameras);
+	void SetSceneCameras(const std::vector<ComponentCamera*>& cameras);
 	void SetAmbientLight(GameObject* ambientLight);
 	void SetDirectionalLight(GameObject* directionalLight);
 
@@ -64,7 +65,7 @@ private:
 	std::unique_ptr<GameObject> root;
 
 	std::vector<GameObject*> sceneGameObjects;
-	std::vector<GameObject*> sceneCameras;
+	std::vector<ComponentCamera*> sceneCameras;
 
 	GameObject* ambientLight;
 	GameObject* directionalLight;
@@ -111,12 +112,12 @@ inline void Scene::SetSceneGameObjects(const std::vector<GameObject*>& gameObjec
 	sceneGameObjects = gameObjects;
 }
 
-inline const std::vector<GameObject*>& Scene::GetSceneCameras() const
+inline const std::vector<ComponentCamera*>& Scene::GetSceneCameras() const
 {
 	return sceneCameras;
 }
 
-inline void Scene::SetSceneCameras(const std::vector<GameObject*>& cameras)
+inline void Scene::SetSceneCameras(const std::vector<ComponentCamera*>& cameras)
 {
 	sceneCameras = cameras;
 }

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -84,7 +84,7 @@ void WindowInspector::InspectSelectedGameObject()
 			{
 				if (child->drawBoundingBoxes == bbDrawn)
 				{
-					child->setDrawBoundingBoxes(!bbDrawn);
+					child->SetDrawBoundingBoxes(!bbDrawn);
 				}
 			}
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/ComponentWindow.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/ComponentWindow.cpp
@@ -87,7 +87,7 @@ void ComponentWindow::DrawEnableComponent()
 		ss << "##Enabled " << windowUUID;
 
 		ImGui::Text("Enabled"); ImGui::SameLine();
-		bool enable = component->GetActive();
+		bool enable = component->IsActive();
 		ImGui::Checkbox(ss.str().c_str(), &enable);
 
 		(enable) ? component->Enable() : component->Disable();

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -377,6 +377,7 @@
     <ClCompile Include="DataModels\Components\ComponentLight.cpp" />
     <ClCompile Include="DataModels\Components\ComponentPointLight.cpp" />
     <ClCompile Include="DataModels\Components\ComponentSpotLight.cpp" />
+    <ClCompile Include="DataModels\Components\DrawableComponent.cpp" />
     <ClCompile Include="DataModels\GameObject\GameObject.cpp" />
     <ClCompile Include="DataModels\Program\Program.cpp" />
     <ClCompile Include="DataModels\Resources\ResourceMaterial.cpp" />
@@ -712,6 +713,7 @@
     <ClInclude Include="DataModels\Components\ComponentLight.h" />
     <ClInclude Include="DataModels\Components\ComponentPointLight.h" />
     <ClInclude Include="DataModels\Components\ComponentSpotLight.h" />
+    <ClInclude Include="DataModels\Components\DrawableComponent.h" />
     <ClInclude Include="DataModels\GameObject\GameObject.h" />
     <ClInclude Include="DataModels\Program\Program.h" />
     <ClInclude Include="DataModels\Resources\EditorResource\EditorResource.h" />

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -403,6 +403,9 @@
     <ClCompile Include="..\External\ImGui\ImGuizmo.cpp">
       <Filter>External\ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="DataModels\Components\DrawableComponent.cpp">
+      <Filter>Source\DataModels\Components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h">
@@ -953,6 +956,9 @@
     </ClInclude>
     <ClInclude Include="..\External\ImGui\ImGuizmo.h">
       <Filter>External\ImGui</Filter>
+    </ClInclude>
+    <ClInclude Include="DataModels\Components\DrawableComponent.h">
+      <Filter>Source\DataModels\Components</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Modules/ModuleRender.h
+++ b/Source/Modules/ModuleRender.h
@@ -9,6 +9,7 @@ struct SDL_Texture;
 struct SDL_Renderer;
 struct SDL_Rect;
 
+class DrawableComponent;
 class Skybox;
 
 class ModuleRender : public Module
@@ -40,11 +41,9 @@ public:
 	void FillRenderList(const Quadtree* quadtree);
 	void AddToRenderList(GameObject* gameObject);
 
-
+	//path and file stuff should be contained in ModuleFileSystem
 	bool IsSupportedPath(const std::string& modelPath);
 	void DrawQuadtree(const Quadtree* quadtree);
-
-	const std::vector<const GameObject*> GetGameObjectsToDraw() const;
 
 private:
 	void UpdateProgram();
@@ -54,7 +53,7 @@ private:
 
 	unsigned vbo;
 	
-	std::vector<const GameObject*> gameObjectsToDraw;
+	std::vector<DrawableComponent*> componentsToDraw;
 	const std::vector<std::string> modelTypes;
 
 	//should this be here?
@@ -93,9 +92,4 @@ inline const std::string& ModuleRender::GetVertexShader() const
 inline const std::string& ModuleRender::GetFragmentShader() const
 {
 	return fragmentShader;
-}
-
-inline const std::vector<const GameObject*> ModuleRender::GetGameObjectsToDraw() const
-{
-	return gameObjectsToDraw;
 }

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -175,7 +175,7 @@ void ModuleScene::SetSceneFromJson(Json& Json)
 	loadedScene->SetSceneQuadTree(std::make_unique<Quadtree>(AABB(float3(-QUADTREE_INITIAL_SIZE / 2, -QUADTREE_INITIAL_ALTITUDE, -QUADTREE_INITIAL_SIZE / 2),
 		float3(QUADTREE_INITIAL_SIZE / 2, QUADTREE_INITIAL_ALTITUDE, QUADTREE_INITIAL_SIZE / 2))));
 	Quadtree* sceneQuadtree = loadedScene->GetSceneQuadTree();
-	std::vector<GameObject*> loadedCameras{};
+	std::vector<ComponentCamera*> loadedCameras{};
 	GameObject* ambientLight = nullptr;
 	GameObject* directionalLight = nullptr;
 
@@ -183,10 +183,7 @@ void ModuleScene::SetSceneFromJson(Json& Json)
 	{
 		sceneQuadtree = loadedScene->GetSceneQuadTree();
 		std::vector<ComponentCamera*> camerasOfObj = obj->GetComponentsByType<ComponentCamera>(ComponentType::CAMERA);
-		if (!camerasOfObj.empty())
-		{
-			loadedCameras.push_back(obj);
-		}
+		loadedCameras.insert(std::end(loadedCameras), std::begin(camerasOfObj), std::end(camerasOfObj));
 
 		std::vector<ComponentLight*> lightsOfObj = obj->GetComponentsByType<ComponentLight>(ComponentType::LIGHT);
 		for (ComponentLight* light : lightsOfObj)


### PR DESCRIPTION
This required creating an intermediate `DrawableComponent` class, which also prompted me to delete Component methods that seemed unnecessary ([and that don't exist in Unity](https://docs.unity3d.com/ScriptReference/Component.html)). I need to check the need for `ComponentCamera::Update`, since I don't see any difference when having it commented. All of the debug draws like lights, camera and bounding boxes will be re-added in a different branch.