### PR TITLE
fix: Camera Focus movement and rotation not aligned

### DIFF
--- a/Source/DataModels/Camera/Camera.cpp
+++ b/Source/DataModels/Camera/Camera.cpp
@@ -80,6 +80,7 @@ bool Camera::Init()
 	frustumOffset = DEFAULT_FRUSTUM_OFFSET;
 
 	position = float3(0.f, 2.f, 5.f);
+	currentRotation = Quat::identity;
 
 	frustum->SetPos(position);
 	frustum->SetFront(-float3::unitZ);

--- a/Source/DataModels/Camera/Camera.h
+++ b/Source/DataModels/Camera/Camera.h
@@ -73,7 +73,7 @@ public:
 	void SetPlaneDistance(float zNear, float zFar);
 	void SetPosition(const float3& position);
 	void SetOrientation(const float3& orientation);
-	void SetLookAt(const float3& lookAt);
+	void SetLookAt(const float3& lookAt, bool& isSameRotation);
 	void SetMoveSpeed(float speed);
 	void SetRotationSpeed(float speed);
 	void SetFrustumOffset(float offset);

--- a/Source/DataModels/Camera/Camera.h
+++ b/Source/DataModels/Camera/Camera.h
@@ -110,7 +110,6 @@ protected:
 
 	float4x4 projectionMatrix;
 	float4x4 viewMatrix;
-	Quat currentRotation;
 	float aspectRatio;
 	float acceleration;
 	float moveSpeed;

--- a/Source/DataModels/Camera/Camera.h
+++ b/Source/DataModels/Camera/Camera.h
@@ -110,7 +110,7 @@ protected:
 
 	float4x4 projectionMatrix;
 	float4x4 viewMatrix;
-	Quat currentRotation = Quat::identity;
+	Quat currentRotation;
 	float aspectRatio;
 	float acceleration;
 	float moveSpeed;

--- a/Source/DataModels/Camera/CameraEngine.cpp
+++ b/Source/DataModels/Camera/CameraEngine.cpp
@@ -52,7 +52,7 @@ bool CameraEngine::Update()
 		if (isFocusing)
 		{
 			if (focusFlag) Focus(App->scene->GetSelectedGameObject());
-			Rotate();
+			//Rotate();
 		}
 		else
 		{
@@ -239,6 +239,7 @@ void CameraEngine::Zoom()
 
 void CameraEngine::Focus(const OBB& obb)
 {
+
 	Sphere boundingSphere = obb.MinimalEnclosingSphere();
 
 	float radius = boundingSphere.r;
@@ -250,10 +251,23 @@ void CameraEngine::Focus(const OBB& obb)
 	//position = boundingSphere.pos - (camDirection * camDistance);
 
 	float3 endposition = boundingSphere.pos - (camDirection * camDistance);
-	position = position.Lerp(endposition, App->GetDeltaTime() * rotationSpeed);
 
-	SetPosition(position);
-	SetLookAt(boundingSphere.pos);
+	bool isSamePosition = false;
+	if (position.Equals(endposition)) 
+	{ 
+		isSamePosition = true; 
+	}
+	else 
+	{ 
+		position = position.Lerp(endposition, App->GetDeltaTime() * rotationSpeed);
+		SetPosition(position);
+	}
+
+	
+	bool isSameRotation;
+	SetLookAt(boundingSphere.pos, isSameRotation);
+
+	if (isSamePosition && isSameRotation) isFocusing = false;
 }
 
 void CameraEngine::Focus(GameObject* gameObject)

--- a/Source/DataModels/Camera/CameraEngine.cpp
+++ b/Source/DataModels/Camera/CameraEngine.cpp
@@ -263,7 +263,10 @@ void CameraEngine::Focus(const OBB& obb)
 	bool isSameRotation = false;
 	SetLookAt(boundingSphere.pos, isSameRotation);
 
-	if (isSamePosition && isSameRotation) isFocusing = false;
+	if (isSamePosition && isSameRotation)
+	{
+		isFocusing = false;
+	}
 }
 
 void CameraEngine::Focus(GameObject* gameObject)

--- a/Source/DataModels/Camera/CameraEngine.cpp
+++ b/Source/DataModels/Camera/CameraEngine.cpp
@@ -52,7 +52,6 @@ bool CameraEngine::Update()
 		if (isFocusing)
 		{
 			if (focusFlag) Focus(App->scene->GetSelectedGameObject());
-			//Rotate();
 		}
 		else
 		{
@@ -341,20 +340,4 @@ void CameraEngine::UnlimitedCursor()
 		SDL_WarpMouseInWindow(App->window->GetWindow(), mouseX, 0);
 		mouseWarped = true;
 	}
-}
-
-void CameraEngine::Rotate()
-{
-	float yaw = 0.f, pitch = 0.f;
-
-	float rotationAngle = RadToDeg(frustum->Front().Normalized().AngleBetween(float3::unitY));
-
-	Quat pitchQuat(frustum->WorldRight(), pitch * App->GetDeltaTime() * rotationSpeed * acceleration);
-	Quat yawQuat(float3::unitY, yaw * App->GetDeltaTime() * rotationSpeed * acceleration);
-
-	float3x3 rotationMatrixX = float3x3::FromQuat(pitchQuat);
-	float3x3 rotationMatrixY = float3x3::FromQuat(yawQuat);
-	float3x3 rotationDeltaMatrix = rotationMatrixY * rotationMatrixX;
-
-	ApplyRotation(rotationDeltaMatrix);
 }

--- a/Source/DataModels/Camera/CameraEngine.cpp
+++ b/Source/DataModels/Camera/CameraEngine.cpp
@@ -248,8 +248,6 @@ void CameraEngine::Focus(const OBB& obb)
 	float camDistance = radius / float(sin(fov / 2.0));
 	vec camDirection = (boundingSphere.pos - frustum->Pos()).Normalized();
 
-	//position = boundingSphere.pos - (camDirection * camDistance);
-
 	float3 endposition = boundingSphere.pos - (camDirection * camDistance);
 
 	bool isSamePosition = false;
@@ -259,12 +257,11 @@ void CameraEngine::Focus(const OBB& obb)
 	}
 	else 
 	{ 
-		position = position.Lerp(endposition, App->GetDeltaTime() * rotationSpeed);
+		position = position.Lerp(endposition, App->GetDeltaTime() * rotationSpeed * 2);
 		SetPosition(position);
 	}
 
-	
-	bool isSameRotation;
+	bool isSameRotation = false;
 	SetLookAt(boundingSphere.pos, isSameRotation);
 
 	if (isSamePosition && isSameRotation) isFocusing = false;

--- a/Source/DataModels/Camera/CameraEngine.h
+++ b/Source/DataModels/Camera/CameraEngine.h
@@ -19,8 +19,6 @@ public:
 	void Focus(const OBB& obb);
 	void Focus(GameObject* gameObject);
 	void Orbit(const OBB& obb);
-	void Rotate();
-
 
 private:
 };

--- a/Source/DataModels/Camera/CameraGameObject.cpp
+++ b/Source/DataModels/Camera/CameraGameObject.cpp
@@ -23,8 +23,6 @@ bool CameraGameObject::Update()
 {
 	if (App->input->GetInFocus())
 	{
-
-
 		projectionMatrix = frustum->ProjectionMatrix();
 		viewMatrix = frustum->ViewMatrix();
 

--- a/Source/Modules/ModulePlayer.cpp
+++ b/Source/Modules/ModulePlayer.cpp
@@ -28,7 +28,7 @@ bool ModulePlayer::Init()
 
 bool ModulePlayer::Start()
 {
-	//Inizialice the player
+	//Initialize the player
 
 	std::vector<GameObject*> cameras = App->scene->GetLoadedScene()->GetSceneCameras();
 	for (GameObject* camera : cameras)


### PR DESCRIPTION
Now that the Camera refactor is finally done, I solved this bug which appeared during the Concept Discovery.

- The problem was that the Focus stops at the frame when the final rotation is achieved. This has been aligned also with position and its Lerp.
- I modified the Slerp algorithm for not needing the current rotation and only use the current front direction.
- The speed has been adjusted too.