### PR TITLE
feat: added state to windows through meta's files

### DIFF
--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -91,7 +91,8 @@ bool Application::CleanUp()
 	bool ret = true;
 
 	for (int i = (int)(modules.size() - 1); i >= 0; --i)
-		ret = modules[i]->CleanUp();
+		if (i != 4) { ret = modules[i]->CleanUp(); }
+	ret = modules[4]->CleanUp();
 
 	return ret;
 }

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -17,11 +17,11 @@ constexpr int FRAMES_BUFFER = 50;
 Application::Application()
 {
 	// Order matters: they will Init/start/update in this order
+	modules.push_back(std::unique_ptr<ModuleFileSystem>(fileSystem = new ModuleFileSystem()));
 	modules.push_back(std::unique_ptr<ModuleWindow>(window = new ModuleWindow()));
 	modules.push_back(std::unique_ptr<ModuleEditor>(editor = new ModuleEditor()));
 	modules.push_back(std::unique_ptr<ModuleInput>(input = new ModuleInput()));
-	modules.push_back(std::unique_ptr<ModuleProgram>(program = new ModuleProgram()));
-	modules.push_back(std::unique_ptr<ModuleFileSystem>(fileSystem = new ModuleFileSystem()));
+	modules.push_back(std::unique_ptr<ModuleProgram>(program = new ModuleProgram()));	
 	modules.push_back(std::unique_ptr<ModuleResources>(resources = new ModuleResources()));
 	modules.push_back(std::unique_ptr<ModuleEngineCamera>(engineCamera = new ModuleEngineCamera()));
 	modules.push_back(std::unique_ptr<ModuleScene>(scene = new ModuleScene()));

--- a/Source/DataModels/Resources/Resource.h
+++ b/Source/DataModels/Resources/Resource.h
@@ -13,6 +13,7 @@ enum class ResourceType
 	Scene,
 	Material,
 	SkyBox,
+	Window,
 };
 
 class Resource

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
@@ -1,31 +1,102 @@
 #include "EditorWindow.h"
 
+#include "physfs.h"
+#include "Application.h"
+#include "../FileSystem/ModuleFileSystem.h"
+#include "../FileSystem/UniqueID.h"
+#include "../FileSystem/Json.h"
+
+
+
+
+
 EditorWindow::EditorWindow(const std::string& name) : Window(name), flags(ImGuiWindowFlags_None),
 	focused(false)
-{
-}
+{}
 
 EditorWindow::~EditorWindow()
-{
+{	
 }
 
-void EditorWindow::Draw(bool& enabled)
+void EditorWindow::Start()
 {
+	load_meta(name.c_str(), enabled);
+}
+
+void EditorWindow::load_meta(std::string name, bool& enable)
+{
+	char* binaryBuffer = {};
+	std::string lib = "Lib/StateWindow/" + name + ".meta";	
+	
+	if (App->fileSystem->Load(lib.c_str(), binaryBuffer) > 0) {
+
+
+		rapidjson::Document doc;
+		Json json(doc, doc);
+		json.fromBuffer(binaryBuffer);
+		std::string buffer = std::string(binaryBuffer);
+		size_t i = buffer.find("State");
+		size_t j = buffer.find("\n", i);
+		if (i != std::string::npos)
+		{
+			if (buffer.substr(i + 8, j - (i + 8)) == "true")
+			{
+				enable = true;
+			}
+			else
+			{
+				enable = false;
+			}
+
+		}
+	}
+	else {
+		enable = true;
+	}	
+	delete binaryBuffer;
+
+}
+
+void EditorWindow::Update_meta(bool enabled,std::string name)
+{
+	
+		rapidjson::Document doc;
+		Json json(doc, doc);
+		json["UID"] = UniqueID::GenerateUID();
+		json["Type"] = "Window";
+		json["State"] = enabled;
+		rapidjson::StringBuffer buffer;
+		json.toBuffer(buffer);
+		std::string lib = "Lib/StateWindow/" + name + ".meta";				
+		App->fileSystem->Save(lib.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());	
+}
+
+
+
+void EditorWindow::Draw()
+{	
 	if (enabled)
 	{
 		if (ImGui::Begin(name.c_str(), &enabled, flags))
-		{
+		{			
+
 			ImGui::SetWindowSize(name.c_str(), GetStartingSize(), ImGuiCond_Once);
 
 			DrawWindowContents();
-			focused = ImGui::IsWindowFocused();
+			focused = ImGui::IsWindowFocused();			
 		}
 		ImGui::End();
-	}
+	}		
 	//The call to ImGui::Begin can change the value of io_enabled
 	//so using "else" will cause the window to remain focused for an extra frame
 	if (!enabled)
 	{
 		focused = false;
 	}
+	
+}
+
+void EditorWindow::CleanUp() 
+{
+	Update_meta(enabled, name);
 }

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
@@ -18,47 +18,7 @@ EditorWindow::~EditorWindow()
 {	
 }
 
-void EditorWindow::Start()
-{
-	LoadMeta(name.c_str(), enabled);
-}
-
-void EditorWindow::LoadMeta(const std::string name,bool& enable)
-{
-	char* binaryBuffer = {};
-	std::string lib = "Lib/StateWindow/" + name + ".meta";	
-	
-	if (App->fileSystem->Exists(lib.c_str())) {
-
-		App->fileSystem->Load(lib.c_str(), binaryBuffer);
-		rapidjson::Document doc;
-		Json json(doc, doc);
-		json.fromBuffer(binaryBuffer);		
-		enable = bool(json["State"]);		
-	}
-	else {
-		enable = true;
-	}	
-	delete binaryBuffer;
-
-}
-
-void EditorWindow::UpdateMeta(bool enabled,const std::string name)
-{
-	
-		rapidjson::Document doc;
-		Json json(doc, doc);		
-		json["Type"] = "Window";
-		json["State"] = enabled;
-		rapidjson::StringBuffer buffer;
-		json.toBuffer(buffer);
-		std::string lib = "Lib/StateWindow/" + name + ".meta";				
-		App->fileSystem->Save(lib.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());	
-}
-
-
-
-void EditorWindow::Draw()
+void EditorWindow::Draw(bool &enabled)
 {	
 	if (enabled)
 	{
@@ -78,10 +38,33 @@ void EditorWindow::Draw()
 	{
 		focused = false;
 	}
+	this->enabled = enabled;
+}
+
+char* EditorWindow::StateWindows()
+{
+	std::string settingsFolder = "Settings/";
+	char* binaryBuffer = {};
+	if (App->fileSystem->Exists(settingsFolder.c_str()))
+	{		
+		std::string set = "Settings/WindowsStates.cong";
+		if (App->fileSystem->Exists(set.c_str()))
+		{
+			App->fileSystem->Load(set.c_str(), binaryBuffer);
+			ENGINE_LOG(binaryBuffer)
+		}
+	}		
+	return binaryBuffer;
 	
 }
 
-void EditorWindow::CleanUp() 
+void EditorWindow::UpdateState(Json &json)
 {
-	UpdateMeta(enabled, name);
+
+	json[name.c_str()] = enabled;
+	/*rapidjson::StringBuffer buffer;
+	json.toBuffer(buffer);
+	std::string lib = "Settings/WindowsStates.cong" ;
+	App->fileSystem->Save(lib.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());*/
 }
+

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
@@ -20,35 +20,21 @@ EditorWindow::~EditorWindow()
 
 void EditorWindow::Start()
 {
-	load_meta(name.c_str(), enabled);
+	LoadMeta(name.c_str(), enabled);
 }
 
-void EditorWindow::load_meta(std::string name, bool& enable)
+void EditorWindow::LoadMeta(const std::string name,bool& enable)
 {
 	char* binaryBuffer = {};
 	std::string lib = "Lib/StateWindow/" + name + ".meta";	
 	
-	if (App->fileSystem->Load(lib.c_str(), binaryBuffer) > 0) {
+	if (App->fileSystem->Exists(lib.c_str())) {
 
-
+		App->fileSystem->Load(lib.c_str(), binaryBuffer);
 		rapidjson::Document doc;
 		Json json(doc, doc);
-		json.fromBuffer(binaryBuffer);
-		std::string buffer = std::string(binaryBuffer);
-		size_t i = buffer.find("State");
-		size_t j = buffer.find("\n", i);
-		if (i != std::string::npos)
-		{
-			if (buffer.substr(i + 8, j - (i + 8)) == "true")
-			{
-				enable = true;
-			}
-			else
-			{
-				enable = false;
-			}
-
-		}
+		json.fromBuffer(binaryBuffer);		
+		enable = bool(json["State"]);		
 	}
 	else {
 		enable = true;
@@ -57,12 +43,11 @@ void EditorWindow::load_meta(std::string name, bool& enable)
 
 }
 
-void EditorWindow::Update_meta(bool enabled,std::string name)
+void EditorWindow::UpdateMeta(bool enabled,const std::string name)
 {
 	
 		rapidjson::Document doc;
-		Json json(doc, doc);
-		json["UID"] = UniqueID::GenerateUID();
+		Json json(doc, doc);		
 		json["Type"] = "Window";
 		json["State"] = enabled;
 		rapidjson::StringBuffer buffer;
@@ -98,5 +83,5 @@ void EditorWindow::Draw()
 
 void EditorWindow::CleanUp() 
 {
-	Update_meta(enabled, name);
+	UpdateMeta(enabled, name);
 }

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.cpp
@@ -50,8 +50,7 @@ char* EditorWindow::StateWindows()
 		std::string set = "Settings/WindowsStates.cong";
 		if (App->fileSystem->Exists(set.c_str()))
 		{
-			App->fileSystem->Load(set.c_str(), binaryBuffer);
-			ENGINE_LOG(binaryBuffer)
+			App->fileSystem->Load(set.c_str(), binaryBuffer);			
 		}
 	}		
 	return binaryBuffer;
@@ -61,10 +60,6 @@ char* EditorWindow::StateWindows()
 void EditorWindow::UpdateState(Json &json)
 {
 
-	json[name.c_str()] = enabled;
-	/*rapidjson::StringBuffer buffer;
-	json.toBuffer(buffer);
-	std::string lib = "Settings/WindowsStates.cong" ;
-	App->fileSystem->Save(lib.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());*/
+	json[name.c_str()] = enabled;	
 }
 

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.h
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.h
@@ -3,18 +3,17 @@
 #include "Windows/Window.h"
 
 #include "imgui.h"
-
+class Json;
 class EditorWindow : public Window
 {
 public:
 	virtual ~EditorWindow() override;
 
-	void Draw() override;
-
+	void Draw(bool &enabled) override;
+	 
 	bool IsFocused() const;	
-	void Start();
-	void CleanUp();
-
+	static char* StateWindows();
+	void UpdateState(Json& json);
 protected:
 	EditorWindow(const std::string& name);
 	virtual void DrawWindowContents() = 0;
@@ -27,6 +26,7 @@ private:
 	bool focused;
 	void LoadMeta(const std::string name, bool& enable);
 	void UpdateMeta(bool enabled, const std::string name);
+	
 };
 
 inline bool EditorWindow::IsFocused() const

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.h
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.h
@@ -9,9 +9,11 @@ class EditorWindow : public Window
 public:
 	virtual ~EditorWindow() override;
 
-	void Draw(bool& enabled) override;
+	void Draw() override;
 
-	bool IsFocused() const;
+	bool IsFocused() const;	
+	void Start();
+	void CleanUp();
 
 protected:
 	EditorWindow(const std::string& name);
@@ -19,9 +21,12 @@ protected:
 	virtual ImVec2 GetStartingSize() const = 0; 
 
 	ImGuiWindowFlags flags;
+	
 
 private:
 	bool focused;
+	void load_meta(std::string name, bool& enable);
+	void Update_meta(bool enabled, std::string name);
 };
 
 inline bool EditorWindow::IsFocused() const

--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.h
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.h
@@ -25,8 +25,8 @@ protected:
 
 private:
 	bool focused;
-	void load_meta(std::string name, bool& enable);
-	void Update_meta(bool enabled, std::string name);
+	void LoadMeta(const std::string name, bool& enable);
+	void UpdateMeta(bool enabled, const std::string name);
 };
 
 inline bool EditorWindow::IsFocused() const

--- a/Source/DataModels/Windows/EditorWindows/WindowAbout.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowAbout.cpp
@@ -1,5 +1,6 @@
 #include "WindowAbout.h"
 
+
 WindowAbout::WindowAbout() : EditorWindow("About")
 {
 }
@@ -8,11 +9,14 @@ WindowAbout::~WindowAbout()
 {
 }
 
+
+
 void WindowAbout::DrawWindowContents()
-{
+{            
 	ImGui::TextUnformatted(TITLE);
 	ImGui::TextWrapped("Description: nullptr");
 	ImGui::Separator();
 	ImGui::TextUnformatted("Author: Horizons Games");
-	ImGui::TextUnformatted("License: MIT");
+	ImGui::TextUnformatted("License: MIT");    
 }
+

--- a/Source/DataModels/Windows/SubWindows/SubWindow.cpp
+++ b/Source/DataModels/Windows/SubWindows/SubWindow.cpp
@@ -11,7 +11,7 @@ SubWindow::~SubWindow()
 {
 }
 
-void SubWindow::Draw()
+void SubWindow::Draw(bool& enabled)
 {
 	if (ImGui::CollapsingHeader(name.c_str(), flags))
 	{

--- a/Source/DataModels/Windows/SubWindows/SubWindow.cpp
+++ b/Source/DataModels/Windows/SubWindows/SubWindow.cpp
@@ -4,13 +4,14 @@ bool SubWindow::defaultEnabled = true;
 
 SubWindow::SubWindow(const std::string& name) : Window(name), flags(ImGuiTreeNodeFlags_None)
 {
+	enabled = defaultEnabled;
 }
 
 SubWindow::~SubWindow()
 {
 }
 
-void SubWindow::Draw(bool& enabled)
+void SubWindow::Draw()
 {
 	if (ImGui::CollapsingHeader(name.c_str(), flags))
 	{

--- a/Source/DataModels/Windows/SubWindows/SubWindow.h
+++ b/Source/DataModels/Windows/SubWindows/SubWindow.h
@@ -9,7 +9,7 @@ class SubWindow : public Window
 public:
 	virtual ~SubWindow() override;
 
-	void Draw(bool& enabled = defaultEnabled) override;
+	void Draw() override;
 
 protected:
 	SubWindow(const std::string& name);

--- a/Source/DataModels/Windows/SubWindows/SubWindow.h
+++ b/Source/DataModels/Windows/SubWindows/SubWindow.h
@@ -9,7 +9,7 @@ class SubWindow : public Window
 public:
 	virtual ~SubWindow() override;
 
-	void Draw() override;
+	void Draw(bool& enabled = defaultEnabled) override;
 
 protected:
 	SubWindow(const std::string& name);

--- a/Source/DataModels/Windows/Window.h
+++ b/Source/DataModels/Windows/Window.h
@@ -7,14 +7,14 @@ class Window
 public:
 	virtual ~Window() {}
 
-	virtual void Draw(bool& enabled) = 0;
+	virtual void Draw() = 0;
 
 	const std::string& GetName() const;
-	
+	bool enabled;
 protected:
-	Window(const std::string& name);
-
+	Window(const std::string& name);	
 	std::string name;
+	
 };
 
 inline Window::Window(const std::string& name)

--- a/Source/DataModels/Windows/Window.h
+++ b/Source/DataModels/Windows/Window.h
@@ -7,7 +7,7 @@ class Window
 public:
 	virtual ~Window() {}
 
-	virtual void Draw() = 0;
+	virtual void Draw(bool &enabled) = 0;
 
 	const std::string& GetName() const;
 	bool enabled;

--- a/Source/DataModels/Windows/WindowMainMenu.cpp
+++ b/Source/DataModels/Windows/WindowMainMenu.cpp
@@ -8,12 +8,14 @@ bool WindowMainMenu::defaultEnabled = true;
 WindowMainMenu::WindowMainMenu(const std::vector< std::unique_ptr<EditorWindow> >& editorWindows) : 
 	Window("Main Menu"), showAbout(false)
 {
+	
+	enabled = defaultEnabled;
 	about = std::make_unique<WindowAbout>();
 	
 	for (const std::unique_ptr<EditorWindow>& window : editorWindows)
 	{
-		std::pair<std::string, bool> windowNameAndEnabled = std::make_pair(window->GetName(), true);
-		windowNamesAndEnabled.push_back(windowNameAndEnabled);
+		std::pair<std::string, std::reference_wrapper<bool>> windowNameAndEnabled = { window->GetName(), window->enabled };
+		windowNamesAndEnabled.push_back(windowNameAndEnabled);		
 	}
 }
 
@@ -21,7 +23,7 @@ WindowMainMenu::~WindowMainMenu()
 {
 }
 
-void WindowMainMenu::Draw(bool& enabled)
+void WindowMainMenu::Draw()
 {
 	if (ImGui::BeginMainMenuBar())
 	{
@@ -38,10 +40,11 @@ void WindowMainMenu::DrawWindowsMenu()
 {
 	if (ImGui::BeginMenu("Windows"))
 	{
-		for (std::pair<std::string, bool>& windowNameAndEnabled : windowNamesAndEnabled)
-		{
-			ImGui::MenuItem(windowNameAndEnabled.first.c_str(), NULL, &windowNameAndEnabled.second);
+		for (auto& windowNameAndEnabled : windowNamesAndEnabled)
+		{			
+			ImGui::MenuItem(windowNameAndEnabled.first.c_str(), NULL, &windowNameAndEnabled.second.get());
 		}
+		
 		ImGui::EndMenu();
 	}
 }
@@ -50,9 +53,9 @@ void WindowMainMenu::DrawAbout()
 {
 	if (ImGui::MenuItem("About"))
 	{
-		showAbout = !showAbout;
+		enabled = !showAbout;
 	}		
-	about->Draw(showAbout);
+	about->Draw();
 }
 
 void WindowMainMenu::DrawGithubLink() const

--- a/Source/DataModels/Windows/WindowMainMenu.cpp
+++ b/Source/DataModels/Windows/WindowMainMenu.cpp
@@ -18,8 +18,7 @@ WindowMainMenu::WindowMainMenu(Json &json ) :
 	for (const char* name:names)
 	{
 		std::pair<std::string, bool> windowNameAndEnabled = std::make_pair<std::string, bool>(std::string(name), bool(json[name]));
-		windowNamesAndEnabled.push_back(windowNameAndEnabled);
-		ENGINE_LOG("NAMES %s plus %s", name, bool(json[name])?"TRUE":"FALSE")
+		windowNamesAndEnabled.push_back(windowNameAndEnabled);		
 	}
 }
 

--- a/Source/DataModels/Windows/WindowMainMenu.cpp
+++ b/Source/DataModels/Windows/WindowMainMenu.cpp
@@ -1,21 +1,25 @@
 #include "WindowMainMenu.h"
-
+#include"Application.h"
+#include "FileSystem/ModuleFileSystem.h"
+#include "FileSystem/Json.h"
 #include "SDL.h"
 
 const std::string WindowMainMenu::repositoryLink = "https://github.com/Horizons-Games/Axolotl-Engine";
 bool WindowMainMenu::defaultEnabled = true;
 
-WindowMainMenu::WindowMainMenu(const std::vector< std::unique_ptr<EditorWindow> >& editorWindows) : 
+WindowMainMenu::WindowMainMenu(Json &json ) :
 	Window("Main Menu"), showAbout(false)
-{
-	
+{	
 	enabled = defaultEnabled;
 	about = std::make_unique<WindowAbout>();
+	std::vector<const char*> names;			
+	json.getVectorNames(names);
 	
-	for (const std::unique_ptr<EditorWindow>& window : editorWindows)
+	for (const char* name:names)
 	{
-		std::pair<std::string, std::reference_wrapper<bool>> windowNameAndEnabled = { window->GetName(), window->enabled };
-		windowNamesAndEnabled.push_back(windowNameAndEnabled);		
+		std::pair<std::string, bool> windowNameAndEnabled = std::make_pair<std::string, bool>(std::string(name), bool(json[name]));
+		windowNamesAndEnabled.push_back(windowNameAndEnabled);
+		ENGINE_LOG("NAMES %s plus %s", name, bool(json[name])?"TRUE":"FALSE")
 	}
 }
 
@@ -23,7 +27,7 @@ WindowMainMenu::~WindowMainMenu()
 {
 }
 
-void WindowMainMenu::Draw()
+void WindowMainMenu::Draw(bool &enabled)
 {
 	if (ImGui::BeginMainMenuBar())
 	{
@@ -42,11 +46,11 @@ void WindowMainMenu::DrawWindowsMenu()
 	{
 		for (auto& windowNameAndEnabled : windowNamesAndEnabled)
 		{			
-			ImGui::MenuItem(windowNameAndEnabled.first.c_str(), NULL, &windowNameAndEnabled.second.get());
+			ImGui::MenuItem(windowNameAndEnabled.first.c_str(), NULL, &windowNameAndEnabled.second);
 		}
 		
 		ImGui::EndMenu();
-	}
+	}	
 }
 
 void WindowMainMenu::DrawAbout()
@@ -55,7 +59,7 @@ void WindowMainMenu::DrawAbout()
 	{
 		enabled = !showAbout;
 	}		
-	about->Draw();
+	about->Draw(enabled);
 }
 
 void WindowMainMenu::DrawGithubLink() const
@@ -77,3 +81,4 @@ void WindowMainMenu::DrawExit() const
 		SDL_PushEvent(&quitEvent);
 	}
 }
+

--- a/Source/DataModels/Windows/WindowMainMenu.h
+++ b/Source/DataModels/Windows/WindowMainMenu.h
@@ -10,11 +10,10 @@ public:
 
 	static const std::string repositoryLink;
 
-	void Draw(bool& enabled = defaultEnabled) override;
+	void Draw() override;
 
 	bool IsWindowEnabled(int windowIndex) const;
-	void SetWindowEnabled(int windowIndex, bool enabled);
-
+	void SetWindowEnabled(int windowIndex, bool &enabled);	
 private:
 	void DrawWindowsMenu();
 	void DrawAbout();
@@ -28,15 +27,15 @@ private:
 	
 	bool showAbout;
 	
-	std::vector<std::pair<std::string, bool> > windowNamesAndEnabled;
+	std::vector<std::pair<std::string, std::reference_wrapper<bool>> > windowNamesAndEnabled;	
 };
 
 inline bool WindowMainMenu::IsWindowEnabled(int windowIndex) const
 {
-	return windowNamesAndEnabled[windowIndex].second;
+	return windowNamesAndEnabled[windowIndex].second.get();	
 }
 
-inline void WindowMainMenu::SetWindowEnabled(int windowIndex, bool enabled)
+inline void WindowMainMenu::SetWindowEnabled(int windowIndex, bool &enabled)
 {
-	windowNamesAndEnabled[windowIndex].second = enabled;
+	windowNamesAndEnabled[windowIndex].second.get() = &enabled;	
 }

--- a/Source/DataModels/Windows/WindowMainMenu.h
+++ b/Source/DataModels/Windows/WindowMainMenu.h
@@ -1,41 +1,41 @@
 #pragma once
 
 #include "EditorWindows/WindowAbout.h"
-
+class Json;
 class WindowMainMenu : public Window
 {
 public:
-	WindowMainMenu(const std::vector<std::unique_ptr<EditorWindow> >& editorWindows);
-	~WindowMainMenu() override;
-
+	WindowMainMenu(Json &json);
+	~WindowMainMenu() override;	
 	static const std::string repositoryLink;
 
-	void Draw() override;
+	void Draw(bool &enabled=defaultEnabled) override;
 
 	bool IsWindowEnabled(int windowIndex) const;
-	void SetWindowEnabled(int windowIndex, bool &enabled);	
+	void SetWindowEnabled(int windowIndex, bool enabled);	
 private:
 	void DrawWindowsMenu();
 	void DrawAbout();
-	
 	void DrawGithubLink() const;
 	void DrawExit() const;
+	
 
 	static bool defaultEnabled;
-
+	
 	std::unique_ptr<WindowAbout> about;
 	
 	bool showAbout;
 	
-	std::vector<std::pair<std::string, std::reference_wrapper<bool>> > windowNamesAndEnabled;	
+	/*std::vector<std::pair<std::string, std::reference_wrapper<bool>> > windowNamesAndEnabled;*/
+	std::vector<std::pair<std::string, bool> > windowNamesAndEnabled;
 };
 
 inline bool WindowMainMenu::IsWindowEnabled(int windowIndex) const
 {
-	return windowNamesAndEnabled[windowIndex].second.get();	
+	return windowNamesAndEnabled[windowIndex].second;	
 }
 
-inline void WindowMainMenu::SetWindowEnabled(int windowIndex, bool &enabled)
+inline void WindowMainMenu::SetWindowEnabled(int windowIndex, bool enabled)
 {
-	windowNamesAndEnabled[windowIndex].second.get() = &enabled;	
+	windowNamesAndEnabled[windowIndex].second = enabled;	
 }

--- a/Source/FileSystem/Json.cpp
+++ b/Source/FileSystem/Json.cpp
@@ -35,6 +35,15 @@ void Json::toBuffer(rapidjson::StringBuffer& buffer)
 	document.Accept(writer);
 }
 
+void Json::getVectorNames(std::vector<const char*>& vec)
+{
+	for (rapidjson::Value::ConstMemberIterator itr = document.MemberBegin();
+		itr != document.MemberEnd(); ++itr)
+	{
+		vec.push_back(itr->name.GetString());		
+	}
+}
+
 Json Json::operator[](unsigned index) const
 {
 	if (!value.IsArray())

--- a/Source/FileSystem/Json.h
+++ b/Source/FileSystem/Json.h
@@ -4,7 +4,7 @@
 #include "rapidjson/stringbuffer.h"
 
 #include <string>
-
+#include <vector>
 class Json 
 {
 public:
@@ -15,6 +15,7 @@ public:
 
 	bool fromBuffer(char*& buffer);
 	void toBuffer(rapidjson::StringBuffer& buffer);
+	void getVectorNames(std::vector<const char*> &vec);
 
 	template<typename T> Json operator[](const T* key) const;
 	Json operator[](const unsigned index) const;

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -14,6 +14,7 @@
 
 const std::string ModuleResources::assetsFolder = "Assets/";
 const std::string ModuleResources::libraryFolder = "Lib/";
+const std::string ModuleResources::settingsFolder = "Settings/";
 
 //creator and destructor can't be inlined
 //because we are using unique pointers with forward declarations
@@ -35,6 +36,7 @@ bool ModuleResources::Start()
 	skyboxImporter = std::make_unique<SkyBoxImporter>();
 
 	CreateAssetAndLibFolders();
+	CreateFolderSettings();
 
 	//remove file separator from library folder
 	LoadResourceStored(libraryFolder.substr(0, libraryFolder.length() - 1).c_str());
@@ -337,6 +339,19 @@ void ModuleResources::CreateAssetAndLibFolders()
 		{
 			App->fileSystem->CreateDirectoryA(libraryFolderOfType.c_str());
 		}
+	}
+}
+
+void ModuleResources::CreateFolderSettings()
+{
+	bool settingsFolderNotCreated = !App->fileSystem->Exists(settingsFolder.c_str());
+	if (settingsFolderNotCreated)
+	{
+		App->fileSystem->CreateDirectoryA(settingsFolder.c_str());
+	}	
+	else
+	{
+		ENGINE_LOG("JUST TRUE")
 	}
 }
 

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -317,7 +317,9 @@ void ModuleResources::CreateAssetAndLibFolders()
 												  ResourceType::Model,
 												  ResourceType::Scene,
 												  ResourceType::Texture,
-												  ResourceType::SkyBox };
+												  ResourceType::SkyBox,
+												  ResourceType::Window
+	};
 	for (ResourceType type : allResourceTypes)
 	{
 		std::string folderOfType = GetFolderOfType(type);
@@ -511,6 +513,8 @@ const std::string ModuleResources::GetNameOfType(ResourceType type)
 		return "Materials";
 	case ResourceType::SkyBox:
 		return "SkyBox";
+	case ResourceType::Window:
+		return "StateWindow";
 	case ResourceType::Unknown:
 	default:
 		return "Unknown";

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -348,11 +348,7 @@ void ModuleResources::CreateFolderSettings()
 	if (settingsFolderNotCreated)
 	{
 		App->fileSystem->CreateDirectoryA(settingsFolder.c_str());
-	}	
-	else
-	{
-		ENGINE_LOG("JUST TRUE")
-	}
+	}		
 }
 
 void ModuleResources::MonitorResources()

--- a/Source/FileSystem/ModuleResources.h
+++ b/Source/FileSystem/ModuleResources.h
@@ -63,6 +63,7 @@ private:
 
 	//folder and file management
 	void CreateAssetAndLibFolders();
+	void CreateFolderSettings();
 	void MonitorResources();
 	void ReImportMaterialAsset(const std::shared_ptr<ResourceMaterial>& materialResource);
 	bool ExistsResourceWithAssetsPath(const std::string& assetsPath, UID& resourceUID);
@@ -77,6 +78,7 @@ private:
 
 	static const std::string assetsFolder;
 	static const std::string libraryFolder;
+	static const std::string settingsFolder;
 	std::map<UID, std::shared_ptr<Resource> > resources;
 
 	std::unique_ptr<ModelImporter> modelImporter;

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -65,16 +65,22 @@ bool ModuleEditor::Start()
 {
 	ImGui_ImplSDL2_InitForOpenGL(App->window->GetWindow(), App->renderer->context);
 	ImGui_ImplOpenGL3_Init(GLSL_VERSION);
+	for (int i = 0; i < windows.size(); ++i) {
+		windows[i].get()->Start();
+	}
 
 	return true;
 }
 
 bool ModuleEditor::CleanUp()
 {
+	for (int i = 0; i < windows.size(); ++i) {
+		windows[i].get()->CleanUp();
+	}
 	ImGui_ImplOpenGL3_Shutdown();
 	ImGui_ImplSDL2_Shutdown();
 	ImGui::DestroyContext();
-
+	
 	windows.clear();
 
 	return true;
@@ -119,9 +125,11 @@ update_status ModuleEditor::Update()
 
 	mainMenu->Draw();
 	for (int i = 0; i < windows.size(); ++i) {
-		bool windowEnabled = mainMenu->IsWindowEnabled(i);
-		windows[i]->Draw(windowEnabled);
-		mainMenu->SetWindowEnabled(i, windowEnabled);
+		//bool windowEnabled = mainMenu->IsWindowEnabled(i);
+		//windows[i]->SetEnable(windowEnabled);
+		windows[i]->Draw();
+		//mainMenu->SetWindowEnabled(i, windows[i].get()->GetEnable());
+		//windows[i]->SetEnable(mainMenu->IsWindowEnabled(i));		
 	}
 
 	return status;

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -65,7 +65,8 @@ bool ModuleEditor::Start()
 {
 	ImGui_ImplSDL2_InitForOpenGL(App->window->GetWindow(), App->renderer->context);
 	ImGui_ImplOpenGL3_Init(GLSL_VERSION);
-	for (int i = 0; i < windows.size(); ++i) {
+	for (int i = 0; i < windows.size(); ++i) 
+	{
 		windows[i].get()->Start();
 	}
 
@@ -74,7 +75,8 @@ bool ModuleEditor::Start()
 
 bool ModuleEditor::CleanUp()
 {
-	for (int i = 0; i < windows.size(); ++i) {
+	for (int i = 0; i < windows.size(); ++i) 
+	{
 		windows[i].get()->CleanUp();
 	}
 	ImGui_ImplOpenGL3_Shutdown();


### PR DESCRIPTION
The metafiles were created to read when the engine starts with the previous window states and to write when the engine closes the last window states.