### PR TITLE
Feat: Material load/save options

### DIFF
--- a/Source/DataModels/Resources/Resource.h
+++ b/Source/DataModels/Resources/Resource.h
@@ -34,11 +34,13 @@ public:
 	virtual void SaveImporterOptions(Json& meta) = 0;
 	virtual void LoadImporterOptions(Json& meta) = 0;
 
+	virtual void SaveLoadOptions(Json& meta) = 0;
+	virtual void LoadLoadOptions(Json& meta) = 0;
+
 	bool IsLoaded() const;
 
 	bool IsChanged() const;
 	void SetChanged(bool changed);
-
 
 protected:
 	Resource(UID resourceUID, 

--- a/Source/DataModels/Resources/ResourceMaterial.cpp
+++ b/Source/DataModels/Resources/ResourceMaterial.cpp
@@ -1,4 +1,5 @@
 #include "ResourceMaterial.h"
+#include "FileSystem/Json.h"
 
 ResourceMaterial::ResourceMaterial(UID resourceUID, const std::string& fileName, const std::string& assetsPath,
 	const std::string& libraryPath) : Resource(resourceUID, fileName, assetsPath, libraryPath),
@@ -12,4 +13,33 @@ ResourceMaterial::ResourceMaterial(UID resourceUID, const std::string& fileName,
 ResourceMaterial::~ResourceMaterial()
 {
 	this->Unload();
+}
+
+
+void ResourceMaterial::SaveLoadOptions(Json& meta)
+{
+	meta["diffuseColor_x"] = (float) diffuseColor.x;
+	meta["diffuseColor_y"] = (float) diffuseColor.y;
+	meta["diffuseColor_z"] = (float) diffuseColor.z;
+	meta["specularColor_x"] = (float) specularColor.x;
+	meta["specularColor_y"] = (float) specularColor.y;
+	meta["specularColor_z"] = (float) specularColor.z;
+	meta["normalStrength"] = (float) normalStrength;
+	meta["smoothness"] = (float)smoothness;
+	meta["metalness"] = (float)metalness;
+	meta["hasMetallicAlpha"] = hasMetallicAlpha;
+}
+
+void ResourceMaterial::LoadLoadOptions(Json& meta)
+{
+	diffuseColor.x = (float) meta["diffuseColor_x"];
+	diffuseColor.y = (float) meta["diffuseColor_y"];
+	diffuseColor.z = (float) meta["diffuseColor_z"];
+	specularColor.x = (float) meta["specularColor_x"];
+	specularColor.y = (float) meta["specularColor_y"];
+	specularColor.z = (float) meta["specularColor_z"];
+	normalStrength = (float) meta["normalStrength"];
+	smoothness = (float) meta["smoothness"];
+	metalness = (float) meta["metalness"];
+	hasMetallicAlpha = meta["hasMetallicAlpha"];
 }

--- a/Source/DataModels/Resources/ResourceMaterial.h
+++ b/Source/DataModels/Resources/ResourceMaterial.h
@@ -6,7 +6,7 @@
 
 class ResourceTexture;
 
-struct OptionsMaterial
+struct LoadOptionsMaterial
 {
 };
 
@@ -23,6 +23,9 @@ public:
 
 	void SaveImporterOptions(Json& meta) override {};
 	void LoadImporterOptions(Json& meta) override {};
+
+	void SaveLoadOptions(Json& meta) override;
+	void LoadLoadOptions(Json& meta) override;
 
 	std::shared_ptr<ResourceTexture>& GetDiffuse();
 	std::shared_ptr<ResourceTexture>& GetNormal();
@@ -43,7 +46,7 @@ public:
 	bool HasMetallicMap();
 	bool HasMetallicAlpha();
 
-	OptionsMaterial& GetOptions();
+	LoadOptionsMaterial& GetLoadOptions();
 
 	//Sets
 	void SetDiffuse(const std::shared_ptr<ResourceTexture>& diffuse);
@@ -80,7 +83,7 @@ private:
 	//bool shininessAlpha;
 	bool hasMetallicAlpha;
 
-	OptionsMaterial options;
+	LoadOptionsMaterial loadOptions;
 };
 
 inline ResourceType ResourceMaterial::GetType() const
@@ -143,9 +146,9 @@ inline float& ResourceMaterial::GetMetalness()
 	return metalness;
 }
 
-inline OptionsMaterial& ResourceMaterial::GetOptions()
+inline LoadOptionsMaterial& ResourceMaterial::GetLoadOptions()
 {
-	return options;
+	return loadOptions;
 }
 
 inline bool ResourceMaterial::HasDiffuse()

--- a/Source/DataModels/Resources/ResourceMesh.h
+++ b/Source/DataModels/Resources/ResourceMesh.h
@@ -23,6 +23,9 @@ public:
 	void SaveImporterOptions(Json& meta) override {};
 	void LoadImporterOptions(Json& meta) override {};
 
+	void SaveLoadOptions(Json& meta) override {};
+	void LoadLoadOptions(Json& meta) override {};
+
 	unsigned int GetVBO() const;
 	unsigned int GetEBO() const;
 	unsigned int GetVAO() const;

--- a/Source/DataModels/Resources/ResourceModel.h
+++ b/Source/DataModels/Resources/ResourceModel.h
@@ -25,6 +25,9 @@ public:
 	void SaveImporterOptions(Json& meta) override {};
 	void LoadImporterOptions(Json& meta) override {};
 
+	void SaveLoadOptions(Json& meta) override {};
+	void LoadLoadOptions(Json& meta) override {};
+
 	const size_t GetNumMeshes() const;
 	const size_t GetNumMaterials() const;
 	const std::vector<std::shared_ptr<ResourceMesh>>& GetMeshes() const;

--- a/Source/DataModels/Resources/ResourceSkyBox.h
+++ b/Source/DataModels/Resources/ResourceSkyBox.h
@@ -23,6 +23,9 @@ public:
 	void SaveImporterOptions(Json& meta) override {};
 	void LoadImporterOptions(Json& meta) override {};
 
+	void SaveLoadOptions(Json& meta) override {};
+	void LoadLoadOptions(Json& meta) override {};
+
 	void LoadVBO();
 	void CreateVAO();
 

--- a/Source/DataModels/Resources/ResourceTexture.cpp
+++ b/Source/DataModels/Resources/ResourceTexture.cpp
@@ -31,10 +31,29 @@ void ResourceTexture::SaveImporterOptions(Json& meta)
 	meta["flipHorizontal"] = importOptions.flipHorizontal;
 }
 
+
 void ResourceTexture::LoadImporterOptions(Json& meta)
 {
 	importOptions.flipVertical = meta["flipVertical"];
 	importOptions.flipHorizontal = meta["flipHorizontal"];
+}
+
+void ResourceTexture::SaveLoadOptions(Json& meta)
+{
+	meta["min"] = (int)loadOptions.min;
+	meta["mag"] = (int)loadOptions.mag;
+	meta["wrapS"] = (int)loadOptions.wrapS;
+	meta["wrapT"] = (int)loadOptions.wrapT;
+	meta["mipMap"] = loadOptions.mipMap;
+}
+
+void ResourceTexture::LoadLoadOptions(Json& meta)
+{
+	loadOptions.min = (TextureMinFilter)(int)meta["min"];
+	loadOptions.mag = (TextureMagFilter)(int)meta["mag"];
+	loadOptions.wrapS = (TextureWrap)(int)meta["wrapS"];
+	loadOptions.wrapT = (TextureWrap)(int)meta["wrapT"];
+	loadOptions.mipMap = (bool)meta["mipMap"];
 }
 
 void ResourceTexture::CreateTexture()

--- a/Source/DataModels/Resources/ResourceTexture.h
+++ b/Source/DataModels/Resources/ResourceTexture.h
@@ -79,6 +79,9 @@ public:
 	void SaveImporterOptions(Json& meta) override;
 	void LoadImporterOptions(Json& meta) override;
 
+	void SaveLoadOptions(Json& meta) override;
+	void LoadLoadOptions(Json& meta) override;
+
 	unsigned int GetGlTexture() const;
 	unsigned int GetWidth() const;
 	unsigned int GetHeight() const;

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.cpp
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.cpp
@@ -1,13 +1,13 @@
 #include "WindowTextureInput.h"
 
-#include "Components/ComponentMaterial.h"
+#include "Windows/SubWindows/ComponentWindows/WindowComponentMaterial.h"
 #include "Resources/ResourceMaterial.h"
 #include "Resources/ResourceTexture.h"
 #include "Application.h"
 #include "FileSystem/ModuleResources.h"
 
-WindowTextureInput::WindowTextureInput(ComponentMaterial* material, TextureType textureType) :
-	WindowFileBrowser(), materialComponent(material), textureType(textureType)
+WindowTextureInput::WindowTextureInput(WindowComponentMaterial* material, TextureType textureType) :
+	WindowFileBrowser(), windowComponent(material), textureType(textureType)
 {
 	dialogName = "Select Texture";
 
@@ -42,33 +42,26 @@ WindowTextureInput::~WindowTextureInput()
 
 void WindowTextureInput::DoThisIfOk()
 {
-	if (materialComponent)
+	if (windowComponent)
 	{
 		std::string filePath = std::string(fileDialogImporter.GetFilePathName());
 		std::shared_ptr<ResourceTexture> texture = App->resources->RequestResource<ResourceTexture>(filePath);
 		
-		std::shared_ptr<ResourceMaterial> material = materialComponent->GetMaterial();
-
-		if (material)
+		switch (textureType)
 		{
-			switch (textureType)
-			{
-			case TextureType::DIFFUSE:
-				material->SetDiffuse(texture);
-				break;
-			case TextureType::NORMAL:
-				material->SetNormal(texture);
-				break;
-			case TextureType::OCCLUSION:
-				break;
-			/*case TextureType::SPECULAR:
-				material->SetSpecular(texture);
-				break;*/
-			case TextureType::METALLIC:
-				material->SetMetallicMap(texture);
-				break;
-			}
-			material->SetChanged(true);
+		case TextureType::DIFFUSE:
+			windowComponent->SetDiffuse(texture);
+			break;
+		case TextureType::NORMAL:
+			windowComponent->SetNormal(texture);
+			break;
+		case TextureType::OCCLUSION:
+			break;
+		case TextureType::METALLIC:
+			windowComponent->SetMetalic(texture);
+			break;
+		default:
+			break;
 		}
 	}
 }

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.h
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.h
@@ -1,19 +1,19 @@
 #pragma once
 #include "Windows/EditorWindows/WindowFileBrowser.h"
 
-class ComponentMaterial;
+class WindowComponentMaterial;
 
 class WindowTextureInput :
     public WindowFileBrowser
 {
 public:
-	WindowTextureInput(ComponentMaterial* material, TextureType textureType);
+	WindowTextureInput(WindowComponentMaterial* material, TextureType textureType);
 	~WindowTextureInput() override;
 
 	void DoThisIfOk() override;
 
 private:
-	ComponentMaterial* materialComponent;
+	WindowComponentMaterial* windowComponent;
 	TextureType textureType;
 
 	friend class WindowComponentMaterial;

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "ComponentWindow.h"
+#include "Math/float3.h"
 
 class ComponentMaterial;
 class WindowTextureInput;
 class WindowMaterialInput;
+class ResourceTexture;
 
 class WindowComponentMaterial : public ComponentWindow
 {
@@ -12,12 +14,26 @@ public:
 	WindowComponentMaterial(ComponentMaterial* component);
 	~WindowComponentMaterial() override;
 
+	void SetDiffuse(const std::shared_ptr<ResourceTexture>& diffuseTexture);
+	void SetMetalic(const std::shared_ptr<ResourceTexture>& metalicMap);
+	void SetNormal(const std::shared_ptr<ResourceTexture>& normalMap);
+
 protected:
 	void DrawWindowContents() override;
 
 private:
 	void DrawSetMaterial();
 	void DrawEmptyMaterial();
+	void InitMaterialValues();
+
+	float3 colorDiffuse;
+	std::shared_ptr<ResourceTexture> diffuseTexture;
+	std::shared_ptr<ResourceTexture> metalicMap;
+	std::shared_ptr<ResourceTexture> normalMap;
+	float smoothness;
+	float metalness;
+	float normalStrength;
+
 
 	std::unique_ptr<WindowMaterialInput> inputMaterial;	   
 	std::unique_ptr<WindowTextureInput> inputTextureDiffuse;
@@ -26,3 +42,17 @@ private:
 	std::unique_ptr<WindowTextureInput> inputTextureMetallic;
 };
 
+inline void WindowComponentMaterial::SetDiffuse(const std::shared_ptr<ResourceTexture>& diffuseTexture)
+{
+	this->diffuseTexture = diffuseTexture;
+}
+
+inline void WindowComponentMaterial::SetMetalic(const std::shared_ptr<ResourceTexture>& metalicMap)
+{
+	this->metalicMap = metalicMap;
+}
+
+inline void WindowComponentMaterial::SetNormal(const std::shared_ptr<ResourceTexture>& normalMap)
+{
+	this->normalMap = normalMap;
+}

--- a/Source/FileSystem/Importers/MaterialImporter.cpp
+++ b/Source/FileSystem/Importers/MaterialImporter.cpp
@@ -143,7 +143,6 @@ void MaterialImporter::Save(const std::shared_ptr<ResourceMaterial>& resource, c
 
 void MaterialImporter::Load(const char* fileBuffer, std::shared_ptr<ResourceMaterial> resource)
 {
-
 	UID texturesUIDs[4];
 	memcpy(texturesUIDs, fileBuffer, sizeof(texturesUIDs));
 
@@ -199,4 +198,9 @@ void MaterialImporter::Load(const char* fileBuffer, std::shared_ptr<ResourceMate
 
 	//delete shininess;
 	delete normalStrenght;
+
+#ifdef ENGINE
+	resource->LoadLoadOptions(meta);
+#endif // ENGINE
+
 }

--- a/Source/FileSystem/Importers/TextureImporter.cpp
+++ b/Source/FileSystem/Importers/TextureImporter.cpp
@@ -121,9 +121,9 @@ void TextureImporter::Import(const char* filePath, std::shared_ptr<ResourceTextu
 		}
 	}
 
-	narrowString = resource->GetLibraryPath() + DDS_TEXTURE_EXTENSION;
-	wideString = std::wstring(narrowString.begin(), narrowString.end());
-	path = wideString.c_str();
+	//narrowString = resource->GetLibraryPath() + DDS_TEXTURE_EXTENSION;
+	//wideString = std::wstring(narrowString.begin(), narrowString.end());
+	//path = wideString.c_str();
 
 	GLint internalFormat;
 	GLenum format, type;
@@ -246,6 +246,7 @@ void TextureImporter::Load(const char* fileBuffer, std::shared_ptr<ResourceTextu
 
 	delete[] pixelsPointer;
 
+#ifndef ENGINE
 	unsigned int options[5];
 	memcpy(options, fileBuffer, sizeof(options));
 
@@ -254,4 +255,5 @@ void TextureImporter::Load(const char* fileBuffer, std::shared_ptr<ResourceTextu
 	resource->GetLoadOptions().wrapS = (TextureWrap)options[2];
 	resource->GetLoadOptions().wrapT = (TextureWrap)options[3];
 	resource->GetLoadOptions().mipMap = options[4];
+#endif // ENGINE
 }

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -287,6 +287,11 @@ void ModuleResources::ReimportResource(UID resourceUID)
 {
 	std::shared_ptr<Resource> resource = resources[resourceUID].lock();
 	CreateMetaFileOfResource(resource);
+	if (resource->GetType() == ResourceType::Material)
+	{
+		std::shared_ptr<ResourceMaterial> materialResource = std::dynamic_pointer_cast<ResourceMaterial>(resource);
+		ReImportMaterialAsset(materialResource);
+	}
 	ImportResourceFromSystem(resource->GetAssetsPath(), resource, resource->GetType());
 }
 
@@ -305,12 +310,14 @@ void ModuleResources::CreateMetaFileOfResource(std::shared_ptr<Resource>& resour
 		resource = CreateResourceOfType(meta["UID"],resource->GetFileName(),resource->GetAssetsPath(),
 			CreateLibraryPath(meta["UID"],resource->GetType()),resource->GetType());
 		resource->LoadImporterOptions(meta);
+		resource->LoadLoadOptions(meta);
 	}
 	else
 	{
 		meta["UID"] = resource->GetUID();
 		meta["Type"] = GetNameOfType(resource->GetType()).c_str();
 		resource->SaveImporterOptions(meta);
+		resource->SaveLoadOptions(meta);
 		rapidjson::StringBuffer buffer;
 		meta.toBuffer(buffer);
 		App->fileSystem->Save(metaPath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());
@@ -493,6 +500,23 @@ void ModuleResources::ReImportMaterialAsset(const std::shared_ptr<ResourceMateri
 	App->fileSystem->SaveInfoMaterial(pathTextures, fileBuffer, size);
 	std::string materialPath = materialResource->GetAssetsPath();
 
+	std::string metaPath = materialResource->GetAssetsPath() + META_EXTENSION;
+	char* metaBuffer = {};
+	App->fileSystem->Load(metaPath.c_str(), metaBuffer);
+	rapidjson::Document doc;
+	Json meta(doc, doc);
+	meta.fromBuffer(metaBuffer);
+	delete metaBuffer;
+
+	meta["DiffuseAssetPath"] = materialResource->GetDiffuse() ? materialResource->GetDiffuse()->GetAssetsPath().c_str() : "";
+	meta["NormalAssetPath"] = materialResource->GetNormal() ? materialResource->GetNormal()->GetAssetsPath().c_str() : "";
+	meta["OcclusionAssetPath"] = materialResource->GetOcclusion() ? materialResource->GetOcclusion()->GetAssetsPath().c_str() : "";
+	//meta["SpecularAssetPath"] = resource->GetSpecular() ? resource->GetSpecular()->GetAssetsPath().c_str() : "";
+	meta["MetallicAssetPath"] = materialResource->GetMetallicMap() ? materialResource->GetMetallicMap()->GetAssetsPath().c_str() : "";
+
+	rapidjson::StringBuffer buffer;
+	meta.toBuffer(buffer);
+	App->fileSystem->Save(metaPath.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());
 	App->fileSystem->Save(materialPath.c_str(), fileBuffer, size);
 	delete fileBuffer;
 }


### PR DESCRIPTION
This solves some problems that occurred in the modification of the material. When you modified a material, the changes were only saved in case of changing a texture, not when we modified other parameters such as smoothness.

Another problem is that the load options in modifiable resources (Like material) had problems when reimporting because information that was only in the binary was lost. That's why now in engine mode load options are imported from the .meta to avoid these problems and in game mode from the binary as it should be.

To avoid having to reimport binary all the time, I add a Apply changes button, just like the one for the texture load/import options, but to ComponentMaterial.