### PR TITLE
Fix: Erase double Load of Mesh/Component

### DIFF
--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -166,7 +166,7 @@ void Scene::DestroyGameObject(GameObject* gameObject)
 void Scene::ConvertModelIntoGameObject(const char* model)
 {
 	std::shared_ptr<ResourceModel> resourceModel = App->resources->RequestResource<ResourceModel>(model);
-	resourceModel->Load();
+	//resourceModel->Load();
 
 	std::string modelName = App->fileSystem->GetFileName(model);
 


### PR DESCRIPTION
This is a fast patch, I'll check it better later.

When you drag and drop 4 different fbx the first one disappears.

For some reason when you load a model, mesh and material, then unload them and THEN load the mesh and material again. This problem appears. It doesn't make any sense because it should be fine, but I deleted the first Load because it was repetitive and patch the problem temporaly for the Level Design Team.