### PR TITLE
fix: resources imported from assets folder instead of original path

### DIFF
--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<Resource> ModuleResources::ImportResource(const std::string& ori
 
 	std::shared_ptr<Resource> importedRes = CreateNewResource(fileName, assetsPath, type);
 	CreateMetaFileOfResource(importedRes);
-	ImportResourceFromSystem(originalPath, importedRes, importedRes->GetType());
+	ImportResourceFromSystem(assetsPath, importedRes, importedRes->GetType());
 	return importedRes;
 }
 


### PR DESCRIPTION
(cherry picked from commit d0c1f90548cb19119caf87d6b103c56051309802)