### PR TITLE
perf[Lights]: delete program where is not necessary

### DIFF
--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -335,168 +335,120 @@ void Scene::RemoveFatherAndChildren(const GameObject* father)
 
 void Scene::GenerateLights()
 {
-	Program* program = App->program->GetProgram(ProgramType::MESHSHADER);
+	// Ambient
 
-	if (program)
-	{
-		program->Activate();
+	glGenBuffers(1, &uboAmbient);
+	glBindBuffer(GL_UNIFORM_BUFFER, uboAmbient);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(float3), nullptr, GL_STATIC_DRAW);
 
-		// Ambient
+	const unsigned bindingAmbient = 1;
 
-		glGenBuffers(1, &uboAmbient);
-		glBindBuffer(GL_UNIFORM_BUFFER, uboAmbient);
-		glBufferData(GL_UNIFORM_BUFFER, sizeof(float3), nullptr, GL_STATIC_DRAW);
+	glBindBufferRange(GL_UNIFORM_BUFFER, bindingAmbient, uboAmbient, 0, sizeof(float3));
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-		const unsigned bindingAmbient = 1;
-		program->BindUniformBlock("Ambient", bindingAmbient);
+	// Directional 
 
-		glBindBufferRange(GL_UNIFORM_BUFFER, bindingAmbient, uboAmbient, 0, sizeof(float3));
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+	glGenBuffers(1, &uboDirectional);
+	glBindBuffer(GL_UNIFORM_BUFFER, uboDirectional);
+	glBufferData(GL_UNIFORM_BUFFER, 32, nullptr, GL_STATIC_DRAW);
 
-		// Directional 
+	const unsigned bindingDirectional = 2;
 
-		glGenBuffers(1, &uboDirectional);
-		glBindBuffer(GL_UNIFORM_BUFFER, uboDirectional);
-		glBufferData(GL_UNIFORM_BUFFER, 32, nullptr, GL_STATIC_DRAW);
+	glBindBufferRange(GL_UNIFORM_BUFFER, bindingDirectional, uboDirectional, 0, sizeof(float4) * 2);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
-		const unsigned bindingDirectional = 2;
-		program->BindUniformBlock("Directional", bindingDirectional);
+	// Point
 
-		glBindBufferRange(GL_UNIFORM_BUFFER, bindingDirectional, uboDirectional, 0, sizeof(float4) * 2);
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+	size_t numPoint = pointLights.size();
 
-		// Point
+	glGenBuffers(1, &ssboPoint);
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboPoint);
+	glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + sizeof(PointLight) * pointLights.size(), nullptr, GL_DYNAMIC_DRAW);
 
-		size_t numPoint = pointLights.size();
+	const unsigned bindingPoint = 3;
 
-		glGenBuffers(1, &ssboPoint);
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboPoint);
-		glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + sizeof(PointLight) * pointLights.size(), nullptr, GL_DYNAMIC_DRAW);
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, bindingPoint, ssboPoint);
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 
-		const unsigned bindingPoint = 3;
-		program->BindShaderStorageBlock("PointLights", bindingPoint);
+	// Spot
 
-		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, bindingPoint, ssboPoint);
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+	size_t numSpot = spotLights.size();
 
-		// Spot
+	glGenBuffers(1, &ssboSpot);
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboSpot);
+	glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + 80 * spotLights.size(), nullptr, GL_DYNAMIC_DRAW);
 
-		size_t numSpot = spotLights.size();
+	const unsigned bindingSpot = 4;
 
-		glGenBuffers(1, &ssboSpot);
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboSpot);
-		glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + 80 * spotLights.size(), nullptr, GL_DYNAMIC_DRAW);
-
-		const unsigned bindingSpot = 4;
-		program->BindShaderStorageBlock("SpotLights", bindingSpot);
-
-		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, bindingSpot, ssboSpot);
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-
-		program->Deactivate();
-	}
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, bindingSpot, ssboSpot);
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
 void Scene::RenderAmbientLight() const
 {
-	Program* program = App->program->GetProgram(ProgramType::MESHSHADER);
+	ComponentLight* ambientComp =
+		static_cast<ComponentLight*>(ambientLight->GetComponent(ComponentType::LIGHT));
+	float3 ambientValue = ambientComp->GetColor();
 
-	if (program)
-	{
-		program->Activate();
-
-		ComponentLight* ambientComp =
-			static_cast<ComponentLight*>(ambientLight->GetComponent(ComponentType::LIGHT));
-		float3 ambientValue = ambientComp->GetColor();
-
-		glBindBuffer(GL_UNIFORM_BUFFER, uboAmbient);
-		glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float3), &ambientValue);
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
-	
-		program->Deactivate();
-	}
+	glBindBuffer(GL_UNIFORM_BUFFER, uboAmbient);
+	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float3), &ambientValue);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void Scene::RenderDirectionalLight() const
 {
-	Program* program = App->program->GetProgram(ProgramType::MESHSHADER);
+	ComponentTransform* dirTransform =
+		static_cast<ComponentTransform*>(directionalLight->GetComponent(ComponentType::TRANSFORM));
+	ComponentLight* dirComp =
+		static_cast<ComponentLight*>(directionalLight->GetComponent(ComponentType::LIGHT));
 
-	if (program)
-	{
-		program->Activate();
+	float3 directionalDir = dirTransform->GetGlobalForward();
+	float4 directionalCol = float4(dirComp->GetColor(), dirComp->GetIntensity());
 
-		ComponentTransform* dirTransform =
-			static_cast<ComponentTransform*>(directionalLight->GetComponent(ComponentType::TRANSFORM));
-		ComponentLight* dirComp =
-			static_cast<ComponentLight*>(directionalLight->GetComponent(ComponentType::LIGHT));
-
-		float3 directionalDir = dirTransform->GetGlobalForward();
-		float4 directionalCol = float4(dirComp->GetColor(), dirComp->GetIntensity());
-
-		glBindBuffer(GL_UNIFORM_BUFFER, uboDirectional);
-		glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float3), &directionalDir);
-		glBufferSubData(GL_UNIFORM_BUFFER, 16, sizeof(float4), &directionalCol);
-		glBindBuffer(GL_UNIFORM_BUFFER, 0);
-	
-		program->Deactivate();
-	}
+	glBindBuffer(GL_UNIFORM_BUFFER, uboDirectional);
+	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float3), &directionalDir);
+	glBufferSubData(GL_UNIFORM_BUFFER, 16, sizeof(float4), &directionalCol);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
 void Scene::RenderPointLights() const
 {
-	Program* program = App->program->GetProgram(ProgramType::MESHSHADER);
+	size_t numPoint = pointLights.size();
 
-	if (program)
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboPoint);
+	glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + sizeof(PointLight) * pointLights.size(), nullptr, GL_DYNAMIC_DRAW);
+	glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(unsigned), &numPoint);
+
+	if (numPoint > 0)
 	{
-		program->Activate();
-
-		size_t numPoint = pointLights.size();
-
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboPoint);
-		glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + sizeof(PointLight) * pointLights.size(), nullptr, GL_DYNAMIC_DRAW);
-		glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(unsigned), &numPoint);
-
-		if (numPoint > 0)
-		{
-			glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16, sizeof(PointLight) * pointLights.size(), &pointLights[0]);
-		}
-		else
-		{
-			glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16, sizeof(PointLight) * pointLights.size(), nullptr);
-		}
-
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-
-		program->Deactivate();
+		glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16, sizeof(PointLight) * pointLights.size(), &pointLights[0]);
 	}
+	else
+	{
+		glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16, sizeof(PointLight) * pointLights.size(), nullptr);
+	}
+
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
 void Scene::RenderSpotLights() const
 {
-	Program* program = App->program->GetProgram(ProgramType::MESHSHADER);
+	size_t numSpot = spotLights.size();
 
-	if (program)
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboSpot);
+	// 64 'cause the whole struct takes 52 bytes, and arrays of structs need to be aligned to 16 in std430
+	glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + 64 * numSpot, nullptr, GL_DYNAMIC_DRAW);
+	glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(unsigned), &numSpot);
+
+	if (numSpot > 0)
 	{
-		program->Activate();
-		size_t numSpot = spotLights.size();
-
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, ssboSpot);
-		// 64 'cause the whole struct takes 52 bytes, and arrays of structs need to be aligned to 16 in std430
-		glBufferData(GL_SHADER_STORAGE_BUFFER, 16 + 64 * numSpot, nullptr, GL_DYNAMIC_DRAW);
-		glBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(unsigned), &numSpot);
-
-		if (numSpot > 0)
+		for (unsigned int i = 0; i < numSpot; ++i)
 		{
-			for (unsigned int i = 0; i < numSpot; ++i)
-			{
-				glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16 + 64 * i, 64, &spotLights[i]);
-			}
+			glBufferSubData(GL_SHADER_STORAGE_BUFFER, 16 + 64 * i, 64, &spotLights[i]);
 		}
-
-		glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-
-		program->Deactivate();
 	}
+
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
 }
 
 void Scene::UpdateScenePointLights()


### PR DESCRIPTION
When you create or assign data to a ssbo is not necessary to use any program. They are stored in globally so any shader can use them.