### PR TITLE
refactor[Engine/animation]: remove extra nodes from hierarchy

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -29,108 +29,153 @@ void WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 {
     assert(gameObject);
 
-    // Delete a GameObject with the SUPR key
-    if (gameObject != App->scene->GetLoadedScene()->GetRoot() &&
-        gameObject != App->scene->GetLoadedScene()->GetAmbientLight() &&
-        gameObject != App->scene->GetLoadedScene()->GetDirectionalLight())
+    // Do not draw assimp extra nodes for translations and rotations
+    if (gameObject->GetName().find("$AssimpFbx$") == std::string::npos)
     {
-        if (App->input->GetKey(SDL_SCANCODE_DELETE) == KeyState::DOWN)
+        // Delete a GameObject with the SUPR key
+        if (gameObject != App->scene->GetLoadedScene()->GetRoot() &&
+            gameObject != App->scene->GetLoadedScene()->GetAmbientLight() &&
+            gameObject != App->scene->GetLoadedScene()->GetDirectionalLight())
         {
-            if (gameObject == App->scene->GetSelectedGameObject())
+            if (App->input->GetKey(SDL_SCANCODE_DELETE) == KeyState::DOWN)
             {
-                App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
-                                                                            // change the focus to its parent
-                App->scene->GetLoadedScene()->GetRootQuadtree()->
-                    RemoveGameObjectAndChildren(gameObject->GetParent());
+                if (gameObject == App->scene->GetSelectedGameObject())
+                {
+                    App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
+                                                                                // change the focus to its parent
+                    App->scene->GetLoadedScene()->GetRootQuadtree()->
+                        RemoveGameObjectAndChildren(gameObject->GetParent());
 
-                App->scene->GetLoadedScene()->DestroyGameObject(gameObject);
+                    App->scene->GetLoadedScene()->DestroyGameObject(gameObject);
 
-                return;
+                    return;
+                }
             }
         }
-    }
 
-    char gameObjectLabel[160];  // Label created so ImGui can differentiate the GameObjects
-                                // that have the same name in the hierarchy window
-    sprintf_s(gameObjectLabel, "%s###%p", gameObject->GetName().c_str(), gameObject);
+        char gameObjectLabel[160];  // Label created so ImGui can differentiate the GameObjects
+                                    // that have the same name in the hierarchy window
+        sprintf_s(gameObjectLabel, "%s###%p", gameObject->GetName().c_str(), gameObject);
 
-    ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+        ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
 
-    std::vector<GameObject*> children = gameObject->GetChildren();
+        std::vector<GameObject*> children = gameObject->GetChildren();
 
-    if (gameObject == App->scene->GetLoadedScene()->GetRoot())
-    {
-        flags |= ImGuiTreeNodeFlags_DefaultOpen;
-    }
-    else
-    {
-        if (children.empty())
+        if (gameObject == App->scene->GetLoadedScene()->GetRoot())
         {
-            flags |= ImGuiTreeNodeFlags_Leaf;
+            flags |= ImGuiTreeNodeFlags_DefaultOpen;
+        }
+        else
+        {
+            if (children.empty())
+            {
+                flags |= ImGuiTreeNodeFlags_Leaf;
+            }
+
+            if (gameObject->GetStateOfSelection() == StateOfSelection::CHILD_SELECTED
+                && StateOfSelection::SELECTED == App->scene->GetSelectedGameObject()->GetStateOfSelection())
+            {
+                ImGui::SetNextItemOpen(true);
+            }
         }
 
-        if (gameObject->GetStateOfSelection() == StateOfSelection::CHILD_SELECTED
-            && StateOfSelection::SELECTED == App->scene->GetSelectedGameObject()->GetStateOfSelection())
-        {            
-            ImGui::SetNextItemOpen(true);
-        }
-    }
-
-    if (gameObject == App->scene->GetSelectedGameObject())
-    {
-        flags |= ImGuiTreeNodeFlags_Selected;
-    }
-
-    ImGui::PushStyleColor(0, (gameObject->IsEnabled() && gameObject->IsActive()) ? white : grey);
-    bool nodeDrawn = ImGui::TreeNodeEx(gameObjectLabel, flags);
-    ImGui::PopStyleColor();
-
-    ImGui::PushID(gameObjectLabel);
-    if (ImGui::IsItemClicked(ImGuiMouseButton_Left) ||
-        (ImGui::IsMouseClicked(ImGuiMouseButton_Right)
-            && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)))
-    {
-        App->scene->ChangeSelectedGameObject(gameObject);
-    }
-
-    if (ImGui::BeginPopupContextItem("RightClickGameObject", ImGuiPopupFlags_MouseButtonRight))
-    {
-        if(gameObject->GetComponent(ComponentType::TRANSFORM) != nullptr)
+        if (gameObject == App->scene->GetSelectedGameObject())
         {
-            if (ImGui::MenuItem("Create Empty child"))
-            {
-                App->scene->GetLoadedScene()->CreateGameObject("Empty GameObject", gameObject);
-            }
+            flags |= ImGuiTreeNodeFlags_Selected;
+        }
 
-            if (ImGui::MenuItem("Create camera"))
-            {
-                GameObject* newCamera =
-                    App->scene->GetLoadedScene()->CreateCameraGameObject("Basic Camera", gameObject);
-            }
+        ImGui::PushStyleColor(0, (gameObject->IsEnabled() && gameObject->IsActive()) ? white : grey);
+        bool nodeDrawn = ImGui::TreeNodeEx(gameObjectLabel, flags);
+        ImGui::PopStyleColor();
 
-            if (ImGui::MenuItem("Create canvas"))
+        ImGui::PushID(gameObjectLabel);
+        if (ImGui::IsItemClicked(ImGuiMouseButton_Left) ||
+            (ImGui::IsMouseClicked(ImGuiMouseButton_Right) &&
+                ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenBlockedByPopup)))
+        {
+            App->scene->ChangeSelectedGameObject(gameObject);
+        }
+
+        if (ImGui::BeginPopupContextItem("RightClickGameObject", ImGuiPopupFlags_MouseButtonRight))
+        {
+            if (gameObject->GetComponent(ComponentType::TRANSFORM) != nullptr)
             {
-                GameObject* newCamera =
-                    App->scene->GetLoadedScene()->CreateCanvasGameObject("Canvas", gameObject);
+                if (ImGui::MenuItem("Create Empty child"))
+                {
+                    App->scene->GetLoadedScene()->CreateGameObject("Empty GameObject", gameObject);
+                }
+
+                if (ImGui::MenuItem("Create camera"))
+                {
+                    GameObject* newCamera =
+                        App->scene->GetLoadedScene()->CreateCameraGameObject("Basic Camera", gameObject);
+                }
+
+                if (ImGui::MenuItem("Create canvas"))
+                {
+                    GameObject* newCamera =
+                        App->scene->GetLoadedScene()->CreateCanvasGameObject("Canvas", gameObject);
+                }
+                //Create Resource
+                if (ImGui::BeginMenu("Create 3D object"))
+                {
+                    if (ImGui::MenuItem("Cube"))
+                    {
+                        App->scene->GetLoadedScene()->Create3DGameObject("Cube", gameObject, Premade3D::CUBE);
+                    }
+                    if (ImGui::MenuItem("Plane"))
+                    {
+                        App->scene->GetLoadedScene()->Create3DGameObject("Plane", gameObject, Premade3D::PLANE);
+                    }
+                    if (ImGui::MenuItem("Cylinder"))
+                    {
+                        App->scene->GetLoadedScene()->Create3DGameObject("Cylinder", gameObject, Premade3D::CYLINDER);
+                    }
+                    if (ImGui::MenuItem("Capsule"))
+                    {
+                        App->scene->GetLoadedScene()->Create3DGameObject("Capsule", gameObject, Premade3D::CAPSULE);
+                    }
+                    if (ImGui::MenuItem("Character"))
+                    {
+                        App->scene->GetLoadedScene()->Create3DGameObject("Character", gameObject, Premade3D::CHARACTER);
+                    }
+                    ImGui::EndMenu();
+                }
+                //Create Light ShortCut
+                if (ImGui::BeginMenu("Create Light"))
+                {
+                    if (ImGui::MenuItem("Spot"))
+                    {
+                        App->scene->GetLoadedScene()->CreateLightGameObject("Spot", gameObject, LightType::SPOT);
+                    }
+                    if (ImGui::MenuItem("Point"))
+                    {
+                        App->scene->GetLoadedScene()->CreateLightGameObject("Point", gameObject, LightType::POINT);
+                    }
+                    ImGui::EndMenu();
+                }
             }
-            //Create Resource
-            if (ImGui::BeginMenu("Create 3D object"))
+            else
             {
-                if (ImGui::MenuItem("Cube"))
+
+                if (ImGui::MenuItem("Create Empty 2D child"))
                 {
-                    App->scene->GetLoadedScene()->Create3DGameObject("Cube", gameObject, Premade3D::CUBE);
+                    App->scene->GetLoadedScene()->CreateGameObject("Empty 2D GameObject", gameObject, false);
                 }
-                if (ImGui::MenuItem("Plane"))
+
+                if (ImGui::MenuItem("Create Text"))
                 {
-                    App->scene->GetLoadedScene()->Create3DGameObject("Plane", gameObject, Premade3D::PLANE);
+                    App->scene->GetLoadedScene()->CreateGameObject("new Text", gameObject, false);
                 }
-                if (ImGui::MenuItem("Cylinder"))
+
+                if (ImGui::MenuItem("Create Image"))
                 {
-                    App->scene->GetLoadedScene()->Create3DGameObject("Cylinder", gameObject, Premade3D::CYLINDER);
+                    App->scene->GetLoadedScene()->CreateUIGameObject("new Image", gameObject, ComponentType::IMAGE);
                 }
-                if (ImGui::MenuItem("Capsule"))
+
+                if (ImGui::MenuItem("Create Button"))
                 {
-                    App->scene->GetLoadedScene()->Create3DGameObject("Capsule", gameObject, Premade3D::CAPSULE);
+                    App->scene->GetLoadedScene()->CreateUIGameObject("new Button", gameObject, ComponentType::BUTTON);
                 }
                 if (ImGui::MenuItem("Character"))
                 {
@@ -151,134 +196,103 @@ void WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
                 }
                 ImGui::EndMenu();
             }
-        }
-        else
-        {
 
-            if (ImGui::MenuItem("Create Empty 2D child"))
+            if (gameObject != App->scene->GetLoadedScene()->GetRoot()) // The root can't be neither deleted nor moved up/down
             {
-                App->scene->GetLoadedScene()->CreateGameObject("Empty 2D GameObject", gameObject, false);
-            }
-
-            if (ImGui::MenuItem("Create Text"))
-            {
-                App->scene->GetLoadedScene()->CreateGameObject("new Text", gameObject, false);
-            }
-
-            if (ImGui::MenuItem("Create Image"))
-            {
-                App->scene->GetLoadedScene()->CreateUIGameObject("new Image", gameObject, ComponentType::IMAGE);
-            }
-
-            if (ImGui::MenuItem("Create Button"))
-            {
-                App->scene->GetLoadedScene()->CreateUIGameObject("new Button", gameObject, ComponentType::BUTTON);
-            }
-            if (ImGui::MenuItem("Character"))
-            {
-                App->scene->GetLoadedScene()->Create3DGameObject("Character", gameObject, Premade3D::CHARACTER);
-            }
-            ImGui::EndMenu();
-        }
-        //Create Light ShortCut
-        if (ImGui::BeginMenu("Create Light"))
-        {
-            if (ImGui::MenuItem("Spot"))
-            {
-                App->scene->GetLoadedScene()->CreateLightGameObject("Spot", gameObject, LightType::SPOT);
-            }
-            if (ImGui::MenuItem("Point"))
-            {
-                App->scene->GetLoadedScene()->CreateLightGameObject("Point", gameObject, LightType::POINT);
-            }
-            ImGui::EndMenu();
-        }
-
-        if (gameObject != App->scene->GetLoadedScene()->GetRoot()) // The root can't be neither deleted nor moved up/down
-        {
-            if (ImGui::MenuItem("Move Up"))
-            {
-                if (!children.empty()
-                    && children[0] != gameObject)
+                if (ImGui::MenuItem("Move Up"))
                 {
-                    gameObject->GetParent()->MoveUpChild(gameObject);
+                    if (!children.empty()
+                        && children[0] != gameObject)
+                    {
+                        gameObject->GetParent()->MoveUpChild(gameObject);
+                    }
+                }
+
+                if (ImGui::MenuItem("Move Down"))
+                {
+                    if (!children.empty()
+                        && children[children.size() - 1] != gameObject)
+                    {
+                        gameObject->GetParent()->MoveDownChild(gameObject);
+                    }
                 }
             }
 
-            if (ImGui::MenuItem("Move Down"))
+            if (gameObject != App->scene->GetLoadedScene()->GetRoot() &&
+                gameObject != App->scene->GetLoadedScene()->GetAmbientLight() &&
+                gameObject != App->scene->GetLoadedScene()->GetDirectionalLight())
             {
-                if (!children.empty()
-                    && children[children.size() - 1] != gameObject)
+                if (ImGui::MenuItem("Delete"))
                 {
-                    gameObject->GetParent()->MoveDownChild(gameObject);
+                    if (gameObject == App->scene->GetSelectedGameObject())
+                    {
+                        App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
+                                                                                    // change the focus to its parent
+                        App->scene->GetLoadedScene()->GetRootQuadtree()->
+                            RemoveGameObjectAndChildren(gameObject->GetParent());
+                    }
+                    App->scene->GetLoadedScene()->GetRootQuadtree()->RemoveGameObjectAndChildren(gameObject);
+                    App->scene->GetLoadedScene()->DestroyGameObject(gameObject);
+
+                    ImGui::EndPopup();
+                    ImGui::PopID();
+                    if (nodeDrawn) // If the parent node is correctly drawn, draw its children
+                    {
+                        ImGui::TreePop();
+                    }
+                    return;
                 }
+            }
+
+            ImGui::EndPopup();
+        }
+        ImGui::PopID();
+
+        if (gameObject != App->scene->GetLoadedScene()->GetRoot()) // The root cannot be moved around
+        {
+            if (ImGui::BeginDragDropSource())
+            {
+                UID thisID = gameObject->GetUID();
+                ImGui::SetDragDropPayload("HIERARCHY", &thisID, sizeof(UID));
+
+                ImGui::EndDragDropSource();
             }
         }
 
-        if (gameObject != App->scene->GetLoadedScene()->GetRoot() &&
-            gameObject != App->scene->GetLoadedScene()->GetAmbientLight() &&
-            gameObject != App->scene->GetLoadedScene()->GetDirectionalLight())
+        if (ImGui::BeginDragDropTarget())
         {
-            if (ImGui::MenuItem("Delete"))
+            if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIERARCHY"))
             {
-                if (gameObject == App->scene->GetSelectedGameObject())
+                UID draggedGameObjectID = *(UID*)payload->Data; // Double pointer to keep track correctly
+                                                                // of the UID of the dragged GameObject
+                GameObject* draggedGameObject =
+                    App->scene->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
+                if (draggedGameObject)
                 {
-                    App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
-                                                                                // change the focus to its parent
-                    App->scene->GetLoadedScene()->GetRootQuadtree()->
-                        RemoveGameObjectAndChildren(gameObject->GetParent());
+                    draggedGameObject->MoveParent(gameObject);
                 }
-                App->scene->GetLoadedScene()->GetRootQuadtree()->RemoveGameObjectAndChildren(gameObject);
-                App->scene->GetLoadedScene()->DestroyGameObject(gameObject);
-
-                ImGui::EndPopup();
-                ImGui::PopID();
-                if (nodeDrawn) // If the parent node is correctly drawn, draw its children
-                {
-                    ImGui::TreePop();
-                }
-                return;
             }
+
+            ImGui::EndDragDropTarget();
         }
 
-        ImGui::EndPopup();
-    }
-    ImGui::PopID();
-
-    if (gameObject != App->scene->GetLoadedScene()->GetRoot()) // The root cannot be moved around
-    {
-        if (ImGui::BeginDragDropSource())
+        if (nodeDrawn) // If the parent node is correctly drawn, draw its children
         {
-            UID thisID = gameObject->GetUID();
-            ImGui::SetDragDropPayload("HIERARCHY", &thisID, sizeof(UID));
-
-            ImGui::EndDragDropSource();
+            for (GameObject* child : children)
+            {
+                DrawRecursiveHierarchy(child);
+            }
+            ImGui::TreePop();
         }
     }
 
-    if (ImGui::BeginDragDropTarget())
+    else
     {
-        if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIERARCHY"))
-        {
-            UID draggedGameObjectID = *(UID*)payload->Data; // Double pointer to keep track correctly
-                                                            // of the UID of the dragged GameObject
-            GameObject* draggedGameObject =
-                App->scene->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
-            if (draggedGameObject)
-            {
-                draggedGameObject->MoveParent(gameObject);
-            }
-        }
+        std::vector<GameObject*> children = gameObject->GetChildren();
 
-        ImGui::EndDragDropTarget();
-    }
-
-    if (nodeDrawn) // If the parent node is correctly drawn, draw its children
-    {
         for (GameObject* child : children)
         {
             DrawRecursiveHierarchy(child);
         }
-        ImGui::TreePop();
     }
 }

--- a/Source/FileSystem/Importers/ModelImporter.cpp
+++ b/Source/FileSystem/Importers/ModelImporter.cpp
@@ -199,7 +199,7 @@ void ModelImporter::Load(const char* fileBuffer, std::shared_ptr<ResourceModel> 
 		memcpy(name, fileBuffer, bytes);
 		fileBuffer += bytes;
 		node->name = std::string(name, nodeHeader[0]);
-		delete name;
+		delete[] name;
 
 		float4x4* transform = new float4x4;
 		bytes = sizeof(float4x4);


### PR DESCRIPTION
Removed the drawing of the extra nodes that assimp creates when importing models, with the information of the pre_rotations and pre_translations applied to the bones (this commit only affects the imgui drawing of the hirearchy, we must keep the nodes themselves for the animations)

<b>Before</b>             |  <b>After</b>
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/18547655/230187974-63fc214c-298c-4e44-826c-19284525a6f6.png)  |  ![image](https://user-images.githubusercontent.com/18547655/230188731-7612a66f-b542-4e88-b0ce-d1f5310ad676.png)


