### PR TITLE
fix: fixed weird error remaining from #242

### DIFF
--- a/Source/DataModels/Components/ComponentMockState.cpp
+++ b/Source/DataModels/Components/ComponentMockState.cpp
@@ -52,8 +52,3 @@ void ComponentMockState::LoadOptions(Json& meta)
 	SetIsFailState((bool)meta["isFailState"]);
 	SetSceneName(tag.c_str());
 }
-
-void ComponentMockState::SetSceneName(const std::string& newTag)
-{
-	sceneName = newTag;
-}

--- a/Source/DataModels/Components/ComponentMockState.cpp
+++ b/Source/DataModels/Components/ComponentMockState.cpp
@@ -52,3 +52,8 @@ void ComponentMockState::LoadOptions(Json& meta)
 	SetIsFailState((bool)meta["isFailState"]);
 	SetSceneName(tag.c_str());
 }
+
+void ComponentMockState::SetSceneName(const std::string& newTag)
+{
+	sceneName = newTag;
+}

--- a/Source/DataModels/Components/ComponentMockState.h
+++ b/Source/DataModels/Components/ComponentMockState.h
@@ -57,8 +57,3 @@ inline std::string ComponentMockState::GetSceneName() const
 	return sceneName;
 }
 
-inline void ComponentMockState::SetSceneName(const std::string& newTag)
-{
-	sceneName = newTag;
-}
-

--- a/Source/DataModels/Components/ComponentMockState.h
+++ b/Source/DataModels/Components/ComponentMockState.h
@@ -57,3 +57,7 @@ inline std::string ComponentMockState::GetSceneName() const
 	return sceneName;
 }
 
+inline void ComponentMockState::SetSceneName(const std::string& newTag)
+{
+	sceneName = newTag;
+}

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -72,10 +72,10 @@ void WindowInspector::InspectSelectedGameObject()
 			std::string tag = lastSelectedGameObject->GetTag();
 			ImGui::Text("Tag");
 			ImGui::SameLine();
+			tag.resize(24);
 			if (ImGui::InputText("##Tag", &tag[0], 24))
 			{
-				//removing c_str makes it so the setter only works when tag.size >= 17. God knows why
-				lastSelectedGameObject->SetTag(tag.c_str());
+				lastSelectedGameObject->SetTag(tag);
 			}
 		}
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMockStates.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMockStates.cpp
@@ -41,10 +41,10 @@ void WindowComponentMockStates::DrawWindowContents()
 
 		ImGui::Text("Scene name");
 		ImGui::SameLine();
+		sceneName.resize(24);
 		if (ImGui::InputText("##Scene name", &sceneName[0], 24))
 		{
-			//removing c_str makes it so the setter only works when tag.size >= 17. God knows why
-			asMockState->SetSceneName(sceneName.c_str());
+			asMockState->SetSceneName(sceneName);
 		}
 	}
 }


### PR DESCRIPTION
Looking at it with Rubén, turns out the error was caused because we didn't reserve enough memory for the buffer, so whenever we added a character it got relocated to another memory address, which ended up causing that weird glitch. The reason it worked after 17 characters where added was because at that point the memory reserved 32 bytes (after doubling from 16), which is less than the 24 bytes of the buffer.