### PR TITLE
chore[main]: allow manual pipeline

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -10,6 +10,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
+  workflow_dispatch
 
 env:
   # Path to the solution file relative to the root of the project.

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -10,7 +10,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "**" ]
-  workflow_dispatch
+  workflow_dispatch:
 
 env:
   # Path to the solution file relative to the root of the project.


### PR DESCRIPTION
Cherrypick of #276. According to the docs (linked in the original MR), the file needs to be in the default branch of the repository in order for the changes to take effect.