### PR TITLE
fix: avoid crash if WindowStates.conf doesn't match the actual windows in ModuleEditor

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/EditorWindow.h
+++ b/Source/DataModels/Windows/EditorWindows/EditorWindow.h
@@ -10,7 +10,9 @@ public:
 
 	void Draw(bool &enabled) override;
 	 
-	bool IsFocused() const;			
+	bool IsFocused() const;		
+	virtual bool DefaultActiveState() const;
+
 protected:
 	EditorWindow(const std::string& name);
 	virtual void DrawWindowContents() = 0;
@@ -25,4 +27,9 @@ private:
 inline bool EditorWindow::IsFocused() const
 {
 	return focused;
+}
+
+inline bool EditorWindow::DefaultActiveState() const
+{
+	return true;
 }

--- a/Source/DataModels/Windows/EditorWindows/WindowConfiguration.h
+++ b/Source/DataModels/Windows/EditorWindows/WindowConfiguration.h
@@ -10,6 +10,8 @@ public:
 	WindowConfiguration();
 	~WindowConfiguration() override;
 
+	bool DefaultActiveState() const override;
+
 protected:
 	void DrawWindowContents() override;
 
@@ -18,3 +20,7 @@ private:
 	std::vector<std::unique_ptr<SubWindow> > collapsingSubWindows;
 };
 
+inline bool WindowConfiguration::DefaultActiveState() const
+{
+	return false;
+}

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -66,7 +66,6 @@ bool ModuleEditor::Init()
 #ifdef ENGINE
 	rapidjson::Document doc;
 	Json json(doc, doc);
-	std::string buffer = StateWindows();
 	
 	windows.push_back(std::unique_ptr<WindowScene>(scene = new WindowScene()));
 	windows.push_back(std::make_unique<WindowConfiguration>());
@@ -75,13 +74,15 @@ bool ModuleEditor::Init()
 	windows.push_back(std::make_unique<WindowHierarchy>());
 	windows.push_back(std::make_unique<WindowEditorControl>());
 	windows.push_back(std::make_unique<WindowAssetFolder>());
-	windows.push_back(std::make_unique<WindowConsole>());	
+	windows.push_back(std::make_unique<WindowConsole>());
+	
+	std::string buffer = StateWindows();
 	if(buffer.empty())
 	{		
 		rapidjson::StringBuffer newBuffer;
-		for (int i = 0; i < windows.size(); ++i)
+		for (const std::unique_ptr<EditorWindow>& window : windows)
 		{
-			json[windows[i].get()->GetName().c_str()]=true;
+			json[window->GetName().c_str()]=true;
 		}
 		json.toBuffer(newBuffer);
 	}
@@ -89,6 +90,23 @@ bool ModuleEditor::Init()
 	{
 		char* bufferPointer = buffer.data();
 		json.fromBuffer(bufferPointer);
+
+		auto windowNameNotInJson = [&json](const std::string& windowName)
+		{
+			std::vector<const char*> namesInJson = json.GetVectorNames();
+			return std::none_of(std::begin(namesInJson), std::end(namesInJson), [&windowName](const char* name)
+				{
+					return windowName == name;
+				});
+		};
+
+		for (const std::unique_ptr<EditorWindow>& window : windows)
+		{
+			if (windowNameNotInJson(window->GetName()))
+			{
+				json[window->GetName().c_str()] = true;
+			}
+		}
 	}
 	
 	mainMenu = std::make_unique<WindowMainMenu>(json);

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -82,7 +82,7 @@ bool ModuleEditor::Init()
 		rapidjson::StringBuffer newBuffer;
 		for (const std::unique_ptr<EditorWindow>& window : windows)
 		{
-			json[window->GetName().c_str()]=true;
+			json[window->GetName().c_str()] = window->DefaultActiveState();
 		}
 		json.toBuffer(newBuffer);
 	}
@@ -104,7 +104,7 @@ bool ModuleEditor::Init()
 		{
 			if (windowNameNotInJson(window->GetName()))
 			{
-				json[window->GetName().c_str()] = true;
+				json[window->GetName().c_str()] = window->DefaultActiveState();
 			}
 		}
 	}

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -128,6 +128,7 @@ bool ModuleEditor::Start()
 
 bool ModuleEditor::CleanUp()
 {
+#ifdef ENGINE
 	rapidjson::Document doc;
 	Json json(doc, doc);	
 	
@@ -138,6 +139,8 @@ bool ModuleEditor::CleanUp()
 	rapidjson::StringBuffer buffer;
 	json.toBuffer(buffer);	
 	App->fileSystem->Save(set.c_str(), buffer.GetString(), (unsigned int)buffer.GetSize());
+#endif
+
 	ImGui_ImplOpenGL3_Shutdown();
 	ImGui_ImplSDL2_Shutdown();
 	ImGui::DestroyContext();


### PR DESCRIPTION
Also allowed each window to define whether it should be opened or closed by default.