### PR TITLE
chore/fix: GameObject::UnlinkChild has [[nodiscard]] tag

### DIFF
--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -176,8 +176,7 @@ void GameObject::MoveParent(GameObject* newParent)
 		return;
 	}
 
-	parent->UnlinkChild(this);
-	newParent->LinkChild(this);
+	newParent->LinkChild(parent->UnlinkChild(this));
 
 	(parent->IsActive() && parent->IsEnabled()) ? ActivateChildren() : DeactivateChildren();
 }

--- a/Source/DataModels/GameObject/GameObject.h
+++ b/Source/DataModels/GameObject/GameObject.h
@@ -40,7 +40,7 @@ public:
 	void InitNewEmptyGameObject(bool is3D=true);
 
 	void LinkChild(GameObject* child);
-	GameObject* UnlinkChild(const GameObject* child);
+	[[nodiscard]] GameObject* UnlinkChild(const GameObject* child);
 
 	UID GetUID() const;
 	std::string GetName() const;

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -229,7 +229,7 @@ GameObject* Scene::CreateLightGameObject(const std::string& name, GameObject* pa
 void Scene::DestroyGameObject(GameObject* gameObject)
 {
 	RemoveFatherAndChildren(gameObject);
-	gameObject->GetParent()->UnlinkChild(gameObject);
+	delete gameObject->GetParent()->UnlinkChild(gameObject);
 }
 
 void Scene::ConvertModelIntoGameObject(const std::string& model)
@@ -293,13 +293,13 @@ void Scene::RemoveFatherAndChildren(const GameObject* father)
 		Component* component = father->GetComponent(ComponentType::CAMERA);
 		if (component)
 		{
-			std::remove_if(std::begin(sceneCameras),
+			std::ignore = std::remove_if(std::begin(sceneCameras),
 				std::end(sceneCameras),
 				[&component](ComponentCamera* camera) { return camera == component; });
 		}
 	}
 
-	std::remove_if(std::begin(sceneGameObjects),
+	std::ignore = std::remove_if(std::begin(sceneGameObjects),
 		std::end(sceneGameObjects),
 		[&father](GameObject* gameObject) { return gameObject == father; });
 }
@@ -579,7 +579,7 @@ void Scene::RemoveStaticObject(GameObject* gameObject)
 
 void Scene::RemoveNonStaticObject(GameObject* gameObject)
 {
-	std::remove_if(std::begin(nonStaticObjects),
+	std::ignore = std::remove_if(std::begin(nonStaticObjects),
 		std::end(nonStaticObjects),
 		[&gameObject](GameObject* anotherObject) { return anotherObject == gameObject; });
 }

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -89,6 +89,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\Source;..\Source\DataModels;..\Source\Modules;..\Source\Scripting;..\External\;..\External\DirectXTex;..\External\ImGui;..\External\glew-2.1.0\include;..\External\SDL\include;..\External\MathGeoLib\Include;..\External\rapidjson\include;..\External\physfs\src;..\External\Zip\include;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem;..\External\Optick;</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatSpecificWarningsAsErrors>4834</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -105,6 +106,7 @@
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\Source;..\Source\DataModels;..\Source\Modules;..\Source\Scripting;..\External\;..\External\DirectXTex;..\External\ImGui;..\External\glew-2.1.0\include;..\External\SDL\include;..\External\MathGeoLib\Include;..\External\rapidjson\include;..\External\physfs\src;..\External\Zip\include;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem;..\External\Optick;</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatSpecificWarningsAsErrors>4834</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,6 +126,7 @@
       <AdditionalIncludeDirectories>..\Source;..\Source\DataModels;..\Source\Modules;..\Source\Scripting;..\Source\FileSystem;..\External\;..\External\DirectXTex;..\External\ImGui;..\External\glew-2.1.0\include;..\External\SDL\include;..\External\MathGeoLib\Include;..\External\physfs\src;..\External\Zip\include;..\External\rapidjson\include;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatSpecificWarningsAsErrors>4834</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,6 +148,7 @@
       <AdditionalIncludeDirectories>..\Source;..\Source\DataModels;..\Source\Modules;..\Source\Scripting;..\Source\FileSystem;..\External\;..\External\DirectXTex;..\External\ImGui;..\External\glew-2.1.0\include;..\External\SDL\include;..\External\MathGeoLib\Include;..\External\physfs\src;..\External\Zip\include;..\External\rapidjson\include;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatSpecificWarningsAsErrors>4834</TreatSpecificWarningsAsErrors>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This will make it so not capturing the return value of `GameObject::UnlinkChild` will result in a compiler error. This will ideally force everyone to be aware that this function gives ownership of the pointer and avoid memory leaks, which there was already one.

Relevant documentation:
https://en.cppreference.com/w/cpp/language/attributes/nodiscard