### PR TITLE
chore: removed unused C++17 definition in External project

### DIFF
--- a/External/ExternalDependencies.vcxproj
+++ b/External/ExternalDependencies.vcxproj
@@ -387,7 +387,6 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugEngine|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>..\External\;..\External\DirectXTex;..\External\DirectXTex\Shaders\Compiled;..\External\ImGui;..\External\glew-2.1.0\include;..\External\SDL\include;..\External\MathGeoLib\Include;..\External\rapidjson\include;..\External\physfs\src;..\External\Zip\include;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem;..\External\RuntimeCompiler\Include;..\External\RuntimeObjectSystem;..\External\Optick</AdditionalIncludeDirectories>
-      <LanguageStandard>stdcpp17</LanguageStandard>
       <LanguageStandard>stdcpp14</LanguageStandard>
     </ClCompile>
     <Link>


### PR DESCRIPTION
I think it was left from some tests done in the scripting branch. It's not an issues since it's not used, but better to have everything cleaned up.