### PR TITLE
fix: material in game mode

### DIFF
--- a/Source/FileSystem/Importers/MaterialImporter.cpp
+++ b/Source/FileSystem/Importers/MaterialImporter.cpp
@@ -194,18 +194,18 @@ void MaterialImporter::Save
 			}
 
 			break;
-	case 1:
+		case 1:
 
-		if (resource->GetSpecular())
-		{
-			specularUID = resource->GetSpecular()->GetUID();
-		}
-		else
-		{
-			specularUID = 0;
-		}
+			if (resource->GetSpecular())
+			{
+				specularUID = resource->GetSpecular()->GetUID();
+			}
+			else
+			{
+				specularUID = 0;
+			}
 
-		break;
+			break;
 	}
 
 	UID texturesUIDs[4] =
@@ -220,19 +220,19 @@ void MaterialImporter::Save
 	float3 specularColor[1] = { resource->GetSpecularColor() };
 	
 	size = sizeof(texturesUIDs) + sizeof(diffuseColor) 
-		+ sizeof(specularColor)  + sizeof(float) * 2 + sizeof(bool);
+		+ sizeof(specularColor)  + sizeof(float) + sizeof(bool) + sizeof(unsigned int);
 
 	char* cursor = new char[size];
 
 	fileBuffer = cursor;
 
-	unsigned int bytes = sizeof(unsigned int);
-	memcpy(cursor, &resource->GetShaderType(), bytes);
+	unsigned int bytes = sizeof(texturesUIDs);
+	memcpy(cursor, texturesUIDs, bytes);
 
 	cursor += bytes;
-
-	bytes = sizeof(texturesUIDs);
-	memcpy(cursor, texturesUIDs, bytes);
+		
+	bytes = sizeof(unsigned int);
+	memcpy(cursor, &resource->GetShaderType(), bytes);
 
 	cursor += bytes;
 
@@ -260,6 +260,8 @@ void MaterialImporter::Load
 {
 	UID texturesUIDs[4];
 	memcpy(texturesUIDs, fileBuffer, sizeof(texturesUIDs));
+
+	fileBuffer += sizeof(texturesUIDs);
 
 	unsigned int* shaderType = new unsigned int;
 
@@ -373,14 +375,12 @@ void MaterialImporter::Load
 
 #endif
 
-	fileBuffer += sizeof(texturesUIDs);
+	float4 diffuseColor;
 
-	float4 difuseColor;
+	memcpy(&diffuseColor, fileBuffer, sizeof(diffuseColor));
+	resource->SetDiffuseColor(diffuseColor);
 
-	memcpy(&difuseColor, fileBuffer, sizeof(difuseColor));
-	resource->SetDiffuseColor(difuseColor);
-
-	fileBuffer += sizeof(difuseColor);
+	fileBuffer += sizeof(diffuseColor);
 
 	float3 specularColor;
 

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -53,7 +53,7 @@ bool ModuleScene::Start()
 	{
 		skybox = std::make_unique<Skybox>(resourceSkybox);
 	}
-#else //ENGINE
+#else // GAME MODE
 	if (loadedScene == nullptr)
 	{
 		LoadSceneFromJson("Lib/Scenes/CantinaScriptsVS2.axolotl");
@@ -74,7 +74,7 @@ bool ModuleScene::Start()
 			componentScript->Start();
 		}
 }
-#endif //GAMEMODE
+#endif
 	selectedGameObject = loadedScene->GetRoot();
 	return true;
 }


### PR DESCRIPTION
Textures were not appearing correctly in game mode because the UIDs of the materials were not correctly passed from Save to Load functions in the binaries. Load and save methods are now working propertly for these materials.