### PR TITLE
feat: Remove/Load new scripts from the graphical interface improved

### DIFF
--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -100,7 +100,7 @@ void WindowComponentScript::DrawWindowContents()
 				
 					label = stringField.name;
 					finalLabel = label + separator + thisID;
-					if (ImGui::InputText(finalLabel.c_str(), const_cast<char*>(value.c_str()), 24))
+					if (ImGui::InputText(finalLabel.c_str(), value.data(), 24))
 					{
 						stringField.setter(value);
 					}

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -35,17 +35,21 @@ void WindowComponentScript::DrawWindowContents()
 	std::string thisID = std::to_string(windowUID);
 	std::string finalLabel = label + separator + thisID;
 
-	if (ImGui::ListBox(finalLabel.c_str(), &current_item, constructors.data(), (int)(constructors.size()), 5))
+	const IScript* scriptObject = script->GetScript();
+
+	if (!scriptObject)
 	{
-		if (script->GetConstructName() != constructors[current_item])
+		if (ImGui::ListBox(finalLabel.c_str(), &current_item, constructors.data(), static_cast<int>(constructors.size()), 5))
 		{
-			ChangeScript(script, constructors[current_item]);
-			ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
+			if (script->GetConstructName() != constructors[current_item])
+			{
+				ChangeScript(script, constructors[current_item]);
+				ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
+			}
 		}
 	}
 
-	const IScript* scriptObject = script->GetScript();
-	if (scriptObject)
+	else
 	{
 		ImGui::Separator();
 
@@ -54,7 +58,7 @@ void WindowComponentScript::DrawWindowContents()
 		std::string fullScriptName = scriptName + scriptExtension;
 		ImGui::Text(fullScriptName.c_str());
 
-		if (ImGui::GetWindowWidth() > (float)fullScriptName.size() * 13.0f)
+		if (ImGui::GetWindowWidth() > static_cast<float>(fullScriptName.size()) * 13.0f)
 		{
 			ImGui::SameLine(ImGui::GetWindowWidth() - 110.0f);
 		}
@@ -99,7 +103,7 @@ void WindowComponentScript::DrawWindowContents()
 				
 					label = stringField.name;
 					finalLabel = label + separator + thisID;
-					if (ImGui::InputText(finalLabel.c_str(), (char*)(value.c_str()), 24))
+					if (ImGui::InputText(finalLabel.c_str(), const_cast<char*>(value.c_str()), 24))
 					{
 						stringField.setter(value);
 					}
@@ -109,7 +113,7 @@ void WindowComponentScript::DrawWindowContents()
 				case FieldType::GAMEOBJECT:
 				{
 					Field<GameObject*> gameObjectField = std::get<Field<GameObject*>>(member);
-					GameObject* value = gameObjectField.getter();
+					const GameObject* value = gameObjectField.getter();
 
 					std::string gameObjectSlot = "Drag a GameObject here";
 					if (value != nullptr)
@@ -125,7 +129,7 @@ void WindowComponentScript::DrawWindowContents()
 					{
 						if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIERARCHY"))
 						{
-							UID draggedGameObjectID = *(UID*)payload->Data;
+							UID draggedGameObjectID = *(static_cast<UID*>(payload->Data));
 							GameObject* draggedGameObject =
 								App->GetModule<ModuleScene>()->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -44,7 +44,7 @@ void WindowComponentScript::DrawWindowContents()
 		}
 	}
 
-	IScript* scriptObject = script->GetScript();
+	const IScript* scriptObject = script->GetScript();
 	if (scriptObject)
 	{
 		ImGui::Separator();

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -123,7 +123,9 @@ void WindowComponentScript::DrawWindowContents()
 
 					label = gameObjectSlot;
 					finalLabel = label + separator + thisID;
+					ImGui::BeginDisabled();
 					ImGui::Button(finalLabel.c_str(), ImVec2(208.0f, 20.0f));
+					ImGui::EndDisabled();
 
 					if (ImGui::BeginDragDropTarget())
 					{

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -41,11 +41,8 @@ void WindowComponentScript::DrawWindowContents()
 	{
 		if (ImGui::ListBox(finalLabel.c_str(), &current_item, constructors.data(), static_cast<int>(constructors.size()), 5))
 		{
-			if (script->GetConstructName() != constructors[current_item])
-			{
-				ChangeScript(script, constructors[current_item]);
-				ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
-			}
+			ChangeScript(script, constructors[current_item]);
+			ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
 		}
 	}
 
@@ -67,14 +64,14 @@ void WindowComponentScript::DrawWindowContents()
 			ImGui::SameLine();
 		}
 
-		label = "Reset Script##";
+		label = "Remove Script##";
 		finalLabel = label + thisID;
 		if (ImGui::Button(finalLabel.c_str()))
 		{
-			ComponentScript* newScript = static_cast<ComponentScript*>(component);
+			ENGINE_LOG("%s REMOVED, showing list of available scripts.", script->GetConstructName().c_str());
 
-			ChangeScript(newScript, newScript->GetConstructName().c_str());
-			ENGINE_LOG("%s RESET, drawing its contents again.", newScript->GetConstructName().c_str());
+			script->SetScript(nullptr); // This deletes the script itself
+			script->SetConstuctor("");	// And this makes that it is also deleted from the serialization
 		}
 
 		for (TypeFieldPair enumAndMember : scriptObject->GetFields())

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -44,134 +44,134 @@ void WindowComponentScript::DrawWindowContents()
 			ChangeScript(script, constructors[current_item]);
 			ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
 		}
+
+		return;
+	}
+
+	ImGui::Separator();
+
+	std::string scriptName = script->GetConstructName().c_str();
+	std::string scriptExtension = ".cpp:";
+	std::string fullScriptName = scriptName + scriptExtension;
+	ImGui::Text(fullScriptName.c_str());
+
+	if (ImGui::GetWindowWidth() > static_cast<float>(fullScriptName.size()) * 13.0f)
+	{
+		ImGui::SameLine(ImGui::GetWindowWidth() - 110.0f);
 	}
 
 	else
 	{
-		ImGui::Separator();
+		ImGui::SameLine();
+	}
 
-		std::string scriptName = script->GetConstructName().c_str();
-		std::string scriptExtension = ".cpp:";
-		std::string fullScriptName = scriptName + scriptExtension;
-		ImGui::Text(fullScriptName.c_str());
+	label = "Remove Script##";
+	finalLabel = label + thisID;
+	if (ImGui::Button(finalLabel.c_str()))
+	{
+		ENGINE_LOG("%s REMOVED, showing list of available scripts.", script->GetConstructName().c_str());
 
-		if (ImGui::GetWindowWidth() > static_cast<float>(fullScriptName.size()) * 13.0f)
+		script->SetScript(nullptr); // This deletes the script itself
+		script->SetConstuctor("");	// And this makes that it is also deleted from the serialization
+	}
+
+	for (TypeFieldPair enumAndMember : scriptObject->GetFields())
+	{
+		ValidFieldType member = enumAndMember.second;
+		switch (enumAndMember.first)
 		{
-			ImGui::SameLine(ImGui::GetWindowWidth() - 110.0f);
-		}
-		else
-		{
-			ImGui::SameLine();
-		}
-
-		label = "Remove Script##";
-		finalLabel = label + thisID;
-		if (ImGui::Button(finalLabel.c_str()))
-		{
-			ENGINE_LOG("%s REMOVED, showing list of available scripts.", script->GetConstructName().c_str());
-
-			script->SetScript(nullptr); // This deletes the script itself
-			script->SetConstuctor("");	// And this makes that it is also deleted from the serialization
-		}
-
-		for (TypeFieldPair enumAndMember : scriptObject->GetFields())
-		{
-			ValidFieldType member = enumAndMember.second;
-			switch (enumAndMember.first)
+			case FieldType::FLOAT:
 			{
-				case FieldType::FLOAT:
+				Field<float> floatField = std::get<Field<float>>(member);
+				float value = floatField.getter();
+
+				label = floatField.name;
+				finalLabel = label + separator + thisID;
+				if (ImGui::DragFloat(finalLabel.c_str(), &value, 0.05f, -50.0f, 50.0f, "%.2f"))
 				{
-					Field<float> floatField = std::get<Field<float>>(member);
-					float value = floatField.getter();
-
-					label = floatField.name;
-					finalLabel = label + separator + thisID;
-					if (ImGui::DragFloat(finalLabel.c_str(), &value, 0.05f, -50.0f, 50.0f, "%.2f"))
-					{
-						floatField.setter(value);
-					}
-					break;
+					floatField.setter(value);
 				}
-
-				case FieldType::STRING:
-				{
-					Field<std::string> stringField = std::get<Field<std::string>>(member);
-					std::string value = stringField.getter();
-				
-					label = stringField.name;
-					finalLabel = label + separator + thisID;
-					if (ImGui::InputText(finalLabel.c_str(), value.data(), 24))
-					{
-						stringField.setter(value);
-					}
-					break;
-				}
-
-				case FieldType::GAMEOBJECT:
-				{
-					Field<GameObject*> gameObjectField = std::get<Field<GameObject*>>(member);
-					const GameObject* value = gameObjectField.getter();
-
-					std::string gameObjectSlot = "Drag a GameObject here";
-					if (value != nullptr)
-					{
-						gameObjectSlot = value->GetName().c_str();
-					}
-
-					label = gameObjectSlot;
-					finalLabel = label + separator + thisID;
-					ImGui::BeginDisabled();
-					ImGui::Button(finalLabel.c_str(), ImVec2(208.0f, 20.0f));
-					ImGui::EndDisabled();
-
-					if (ImGui::BeginDragDropTarget())
-					{
-						if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIERARCHY"))
-						{
-							UID draggedGameObjectID = *(static_cast<UID*>(payload->Data));
-							GameObject* draggedGameObject =
-								App->GetModule<ModuleScene>()->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
-
-							if (draggedGameObject)
-							{
-								gameObjectField.setter(draggedGameObject);
-							}
-						}
-
-						ImGui::EndDragDropTarget();
-					}
-
-					ImGui::SameLine(0.0f, 3.0f);
-					ImGui::Text(gameObjectField.name.c_str());
-					ImGui::SameLine();
-
-					label = "Remove GO##";
-					finalLabel = label + thisID;
-					if (ImGui::Button(finalLabel.c_str()))
-					{
-						gameObjectField.setter(nullptr);
-					}
-
-					break;
-				}
-
-				case FieldType::BOOLEAN:
-				{
-					Field<bool> booleanField = std::get<Field<bool>>(member);
-					bool value = booleanField.getter();
-
-					label = booleanField.name;
-					finalLabel = label + separator + thisID;
-					if (ImGui::Checkbox(finalLabel.c_str(), &value))
-					{
-						booleanField.setter(value);
-					}
-					break;
-				}
-
-				default:
-					break;
+				break;
 			}
+
+			case FieldType::STRING:
+			{
+				Field<std::string> stringField = std::get<Field<std::string>>(member);
+				std::string value = stringField.getter();
+
+				label = stringField.name;
+				finalLabel = label + separator + thisID;
+				if (ImGui::InputText(finalLabel.c_str(), value.data(), 24))
+				{
+					stringField.setter(value);
+				}
+				break;
+			}
+
+			case FieldType::GAMEOBJECT:
+			{
+				Field<GameObject*> gameObjectField = std::get<Field<GameObject*>>(member);
+				const GameObject* value = gameObjectField.getter();
+
+				std::string gameObjectSlot = "Drag a GameObject here";
+				if (value != nullptr)
+				{
+					gameObjectSlot = value->GetName().c_str();
+				}
+
+				label = gameObjectSlot;
+				finalLabel = label + separator + thisID;
+				ImGui::BeginDisabled();
+				ImGui::Button(finalLabel.c_str(), ImVec2(208.0f, 20.0f));
+				ImGui::EndDisabled();
+
+				if (ImGui::BeginDragDropTarget())
+				{
+					if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("HIERARCHY"))
+					{
+						UID draggedGameObjectID = *(static_cast<UID*>(payload->Data));
+						GameObject* draggedGameObject =
+							App->GetModule<ModuleScene>()->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
+
+						if (draggedGameObject)
+						{
+							gameObjectField.setter(draggedGameObject);
+						}
+					}
+
+					ImGui::EndDragDropTarget();
+				}
+
+				ImGui::SameLine(0.0f, 3.0f);
+				ImGui::Text(gameObjectField.name.c_str());
+				ImGui::SameLine();
+
+				label = "Remove GO##";
+				finalLabel = label + thisID;
+				if (ImGui::Button(finalLabel.c_str()))
+				{
+					gameObjectField.setter(nullptr);
+				}
+
+				break;
+			}
+
+			case FieldType::BOOLEAN:
+			{
+				Field<bool> booleanField = std::get<Field<bool>>(member);
+				bool value = booleanField.getter();
+
+				label = booleanField.name;
+				finalLabel = label + separator + thisID;
+				if (ImGui::Checkbox(finalLabel.c_str(), &value))
+				{
+					booleanField.setter(value);
+				}
+				break;
+			}
+
+			default:
+				break;
 		}
 	}
 }


### PR DESCRIPTION
Not improved in a performance way, but in a visual way:

- The reset script button has been changed to a remove button.
- The list of scripts is not shown if a script is already loaded.
- Fixed a couple warnings (C-style casts and const variables)