### PR TITLE
Fix: Add Metalness and Smothness on GameMode

### DIFF
--- a/Source/FileSystem/Importers/MaterialImporter.cpp
+++ b/Source/FileSystem/Importers/MaterialImporter.cpp
@@ -220,7 +220,7 @@ void MaterialImporter::Save
 	float3 specularColor[1] = { resource->GetSpecularColor() };
 	
 	size = sizeof(texturesUIDs) + sizeof(diffuseColor) 
-		+ sizeof(specularColor)  + sizeof(float) + sizeof(bool) + sizeof(unsigned int);
+		+ sizeof(specularColor)  + sizeof(float) * 3 + sizeof(bool) + sizeof(unsigned int);
 
 	char* cursor = new char[size];
 
@@ -253,6 +253,16 @@ void MaterialImporter::Save
 
 	bytes = sizeof(bool);
 	memcpy(cursor, &resource->GetTransparent(), bytes);
+
+	cursor += bytes;
+
+	bytes = sizeof(float);
+	memcpy(cursor, &resource->GetSmoothness(), bytes);
+
+	cursor += bytes;
+
+	bytes = sizeof(float);
+	memcpy(cursor, &resource->GetMetalness(), bytes);
 }
 
 void MaterialImporter::Load
@@ -402,6 +412,18 @@ void MaterialImporter::Load
 	resource->SetTransparent(*isTransparent);
 
 	fileBuffer += sizeof(bool);
+
+	float smoothness;
+	memcpy(&smoothness, fileBuffer, sizeof(float));
+	resource->SetSmoothness(smoothness);
+
+	fileBuffer += sizeof(float);
+
+	float metalness;
+	memcpy(&metalness, fileBuffer, sizeof(float));
+	resource->SetMetalness(metalness);
+
+	fileBuffer += sizeof(float);
 
 	delete shaderType;
 	delete normalStrenght;


### PR DESCRIPTION
Fix bug #347 

In GameMode we don't have the asset folder, so we can't acces the metas and need to save the load options (The importer options aren't necessary) in the binary for that purpose. This was made for all the editable options on Material on VS1.

I Updated the Material binary to save smoothness and metalness, it was forgotten in the latest Material refactor.