### PR TITLE
feat: Create scripts into the Script folder using the engine's UI

### DIFF
--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -233,14 +233,25 @@ void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
 	char* headerBuffer = nullptr;
 	char* sourceBuffer = nullptr;
 
-	unsigned int headerBufferSize = App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateHeaderScript", headerBuffer);
-	unsigned int sourceBufferSize = App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateSourceScript", sourceBuffer);
+	unsigned int headerBufferSize = 
+		App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateHeaderScript", headerBuffer);
+	unsigned int sourceBufferSize = 
+		App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateSourceScript", sourceBuffer);
 
 	std::string scriptsPath = "Scripts/";
 
 	std::string scriptHeaderPath = scriptsPath + scriptName + ".h";
 	std::string scriptSourcePath = scriptsPath + scriptName + ".cpp";
 
-	App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferSize);
-	App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferSize);
+	// Both header and source have the same name, so only checking the header is enough
+	if (!App->GetModule<ModuleFileSystem>()->Exists(scriptHeaderPath.c_str()))
+	{
+		App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferSize);
+		App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferSize);
+	}
+
+	else
+	{
+		ENGINE_LOG("That name is already in use, please use a different one");
+	}
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -44,6 +44,22 @@ void WindowComponentScript::DrawWindowContents()
 			ChangeScript(script, constructors[current_item]);
 			ENGINE_LOG("%s SELECTED, drawing its contents.", script->GetConstructName().c_str());
 		}
+
+		label = "Create Script##";
+		finalLabel = label + thisID;
+		if (ImGui::Button(finalLabel.c_str()))
+		{
+			ImGui::OpenPopup("Create new script");
+		}
+
+		ImGui::SetNextWindowSize(ImVec2(280, 75));
+
+		if (ImGui::BeginPopupModal("Create new script", nullptr,
+			ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar))
+		{
+			CreateNewScript();
+			ImGui::EndPopup();
+		}
 	}
 
 	else
@@ -183,4 +199,23 @@ void WindowComponentScript::ChangeScript(ComponentScript* newScript, const char*
 	Iscript->SetGameObject(component->GetOwner());
 	Iscript->SetApplication(App.get());
 	newScript->SetScript(Iscript);
+}
+
+void WindowComponentScript::CreateNewScript() const
+{
+	static char name[FILENAME_MAX] = "NewScript";
+	ImGui::InputText("Script Name", name, IM_ARRAYSIZE(name));
+	ImGui::NewLine();
+
+	ImGui::SameLine(ImGui::GetWindowWidth() - 120);
+	if (ImGui::Button("Save", ImVec2(50, 20)))
+	{
+		ImGui::CloseCurrentPopup();
+	}
+
+	ImGui::SameLine(ImGui::GetWindowWidth() - 60);
+	if (ImGui::Button("Cancel"))
+	{
+		ImGui::CloseCurrentPopup();
+	}
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -62,7 +62,7 @@ void WindowComponentScript::DrawWindowContents()
 		if (ImGui::BeginPopupModal("Create new script", nullptr,
 			ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar))
 		{
-			CreateNewScript();
+			OpenCreateNewScriptPopUp();
 			ImGui::EndPopup();
 		}
 	}
@@ -228,6 +228,18 @@ void WindowComponentScript::OpenCreateNewScriptPopUp()
 
 void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
 {
+	std::string scriptsPath = "Scripts/";
+
+	std::string scriptHeaderPath = scriptsPath + scriptName + ".h";
+	std::string scriptSourcePath = scriptsPath + scriptName + ".cpp";
+
+	// Both header and source have the same name, so only checking the header is enough
+	if (App->GetModule<ModuleFileSystem>()->Exists(scriptHeaderPath.c_str()))
+	{
+		ENGINE_LOG("That name is already in use, please use a different one");
+		return;
+	}
+
 	ENGINE_LOG("New script %s created", scriptName.c_str());
 
 	char* headerBuffer = nullptr;
@@ -245,22 +257,8 @@ void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
 	headerBuffer = headerBufferAsString.data();
 	sourceBuffer = sourceBufferAsString.data();
 
-	std::string scriptsPath = "Scripts/";
-
-	std::string scriptHeaderPath = scriptsPath + scriptName + ".h";
-	std::string scriptSourcePath = scriptsPath + scriptName + ".cpp";
-
-	// Both header and source have the same name, so only checking the header is enough
-	if (!App->GetModule<ModuleFileSystem>()->Exists(scriptHeaderPath.c_str()))
-	{
-		App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferAsString.size());
-		App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferAsString.size());
-	}
-
-	else
-	{
-		ENGINE_LOG("That name is already in use, please use a different one");
-	}
+	App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferAsString.size());
+	App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferAsString.size());
 }
 
 void WindowComponentScript::ReplaceSubstringsInString(std::string& stringToReplace,

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -206,7 +206,7 @@ void WindowComponentScript::ChangeScript(ComponentScript* newScript, const char*
 	newScript->SetScript(Iscript);
 }
 
-void WindowComponentScript::CreateNewScript()
+void WindowComponentScript::OpenCreateNewScriptPopUp()
 {
 	static char name[FILENAME_MAX] = "NewScript";
 	ImGui::InputText("Script Name", name, IM_ARRAYSIZE(name));
@@ -233,10 +233,17 @@ void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
 	char* headerBuffer = nullptr;
 	char* sourceBuffer = nullptr;
 
-	unsigned int headerBufferSize = 
-		App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateHeaderScript", headerBuffer);
-	unsigned int sourceBufferSize = 
-		App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateSourceScript", sourceBuffer);
+	App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateHeaderScript", headerBuffer);
+	App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateSourceScript", sourceBuffer);
+
+	std::string headerBufferAsString = headerBuffer;
+	std::string sourceBufferAsString = sourceBuffer;
+
+	ReplaceSubstringsInString(headerBufferAsString, "{0}", scriptName);
+	ReplaceSubstringsInString(sourceBufferAsString, "{0}", scriptName);
+
+	headerBuffer = headerBufferAsString.data();
+	sourceBuffer = sourceBufferAsString.data();
 
 	std::string scriptsPath = "Scripts/";
 
@@ -246,12 +253,28 @@ void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
 	// Both header and source have the same name, so only checking the header is enough
 	if (!App->GetModule<ModuleFileSystem>()->Exists(scriptHeaderPath.c_str()))
 	{
-		App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferSize);
-		App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferSize);
+		App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferAsString.size());
+		App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferAsString.size());
 	}
 
 	else
 	{
 		ENGINE_LOG("That name is already in use, please use a different one");
+	}
+}
+
+void WindowComponentScript::ReplaceSubstringsInString(std::string& stringToReplace,
+	const std::string& from, const std::string& to)
+{
+	if (from.empty())
+	{
+		return;
+	}
+
+	size_t startPos = 0;
+	while ((startPos = stringToReplace.find(from, startPos)) != std::string::npos)
+	{
+		stringToReplace.replace(startPos, from.length(), to);
+		startPos += to.length();
 	}
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.cpp
@@ -1,8 +1,13 @@
 #include "WindowComponentScript.h"
-#include "Components/ComponentScript.h"
+
 #include "Application.h"
 #include "Scene/Scene.h"
+
 #include "Modules/ModuleScene.h"
+#include "FileSystem/ModuleFileSystem.h"
+
+#include "Components/ComponentScript.h"
+
 #include "ScriptFactory.h"
 #include "IScript.h"
 
@@ -201,7 +206,7 @@ void WindowComponentScript::ChangeScript(ComponentScript* newScript, const char*
 	newScript->SetScript(Iscript);
 }
 
-void WindowComponentScript::CreateNewScript() const
+void WindowComponentScript::CreateNewScript()
 {
 	static char name[FILENAME_MAX] = "NewScript";
 	ImGui::InputText("Script Name", name, IM_ARRAYSIZE(name));
@@ -210,6 +215,7 @@ void WindowComponentScript::CreateNewScript() const
 	ImGui::SameLine(ImGui::GetWindowWidth() - 120);
 	if (ImGui::Button("Save", ImVec2(50, 20)))
 	{
+		AddNewScriptToProject(name);
 		ImGui::CloseCurrentPopup();
 	}
 
@@ -218,4 +224,23 @@ void WindowComponentScript::CreateNewScript() const
 	{
 		ImGui::CloseCurrentPopup();
 	}
+}
+
+void WindowComponentScript::AddNewScriptToProject(const std::string& scriptName)
+{
+	ENGINE_LOG("New script %s created", scriptName.c_str());
+
+	char* headerBuffer = nullptr;
+	char* sourceBuffer = nullptr;
+
+	unsigned int headerBufferSize = App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateHeaderScript", headerBuffer);
+	unsigned int sourceBufferSize = App->GetModule<ModuleFileSystem>()->Load("Source/PreMades/TemplateSourceScript", sourceBuffer);
+
+	std::string scriptsPath = "Scripts/";
+
+	std::string scriptHeaderPath = scriptsPath + scriptName + ".h";
+	std::string scriptSourcePath = scriptsPath + scriptName + ".cpp";
+
+	App->GetModule<ModuleFileSystem>()->Save(scriptHeaderPath.c_str(), headerBuffer, headerBufferSize);
+	App->GetModule<ModuleFileSystem>()->Save(scriptSourcePath.c_str(), sourceBuffer, sourceBufferSize);
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
@@ -19,7 +19,8 @@ protected:
 private:
 	void ChangeScript(ComponentScript* newScript, const char* selectedScript);
 
-	void CreateNewScript() const;
+	void CreateNewScript();
+	void AddNewScriptToProject(const std::string& scriptName);
 
 	UID windowUID;
 };

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
@@ -18,6 +18,9 @@ protected:
 
 private:
 	void ChangeScript(ComponentScript* newScript, const char* selectedScript);
+
+	void CreateNewScript() const;
+
 	UID windowUID;
 };
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentScript.h
@@ -19,8 +19,11 @@ protected:
 private:
 	void ChangeScript(ComponentScript* newScript, const char* selectedScript);
 
-	void CreateNewScript();
+	void OpenCreateNewScriptPopUp();
 	void AddNewScriptToProject(const std::string& scriptName);
+
+	void ReplaceSubstringsInString(std::string& stringToReplace,
+		const std::string& from, const std::string& to);
 
 	UID windowUID;
 };

--- a/Source/PreMades/TemplateHeaderScript
+++ b/Source/PreMades/TemplateHeaderScript
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Scripting\Script.h"
+#include "RuntimeInclude.h"
+
+RUNTIME_MODIFIABLE_INCLUDE;
+
+class {0} : public Script
+{
+public:
+	{0}();
+	~{0}() override = default;
+
+	void Start() override;
+	void Update(float deltaTime) override;
+};

--- a/Source/PreMades/TemplateSourceScript
+++ b/Source/PreMades/TemplateSourceScript
@@ -1,0 +1,15 @@
+#include "{0}.h"
+
+REGISTERCLASS({0});
+
+{0}::{0}() : Script()
+{
+}
+
+void {0}::Start()
+{
+}
+
+void {0}::Update(float deltaTime)
+{
+}

--- a/Source/Scripting/ScriptFactory.cpp
+++ b/Source/Scripting/ScriptFactory.cpp
@@ -153,7 +153,8 @@ IScript* ScriptFactory::GetScript(const char* name)
 	return it == std::end(allScripts) ? nullptr : it->second;
 }
 
-void ScriptFactory::IncludeDirs() {
+void ScriptFactory::IncludeDirs() 
+{
 	FileSystemUtils::Path basePath = pRuntimeObjectSystem->FindFile(__FILE__).ParentPath().ParentPath().ParentPath() / "Source";
 	FileSystemUtils::Path source = basePath;
 	pRuntimeObjectSystem->AddIncludeDir(source.c_str());


### PR DESCRIPTION
Now, under the list of available scripts that you can choose in a `ComponentScript`, there is a button to create new scripts with any given name. Those scripts will go directly to your local Axolotl-Engine/Game/Scripts folder, and from there you'll only have to include them in the project through VS to be able to use them (we are working on doing that automatically, but for now we haven't found a way, so you'll have to do it manually for the time being).