### PR TITLE
Fix: rigid body enable

### DIFF
--- a/Source/DataModels/Components/ComponentRigidBody.cpp
+++ b/Source/DataModels/Components/ComponentRigidBody.cpp
@@ -283,6 +283,18 @@ void ComponentRigidBody::LoadOptions(Json& meta)
     SetGravity({ 0, (float)meta["gravity_Y"], 0 });
 }
 
+void ComponentRigidBody::Enable()
+{
+    active = true;
+    App->GetModule<ModulePhysics>()->AddRigidBody(this, rigidBody);
+}
+
+void ComponentRigidBody::Disable()
+{
+    active = false;
+    App->GetModule<ModulePhysics>()->RemoveRigidBody(this, rigidBody);
+}
+
 void ComponentRigidBody::RemoveRigidBodyFromSimulation()
 {
     App->GetModule<ModulePhysics>()->RemoveRigidBody(this, rigidBody);

--- a/Source/DataModels/Components/ComponentRigidBody.h
+++ b/Source/DataModels/Components/ComponentRigidBody.h
@@ -49,6 +49,9 @@ public:
     void SaveOptions(Json& meta) override;
     void LoadOptions(Json& meta) override;
 
+    void Enable() override;
+    void Disable() override;
+
     void SetIsKinematic(bool isKinematic);
     bool GetIsKinematic() const;
 
@@ -110,8 +113,6 @@ public:
 
     void DisablePositionController();
     void DisableRotationController();
-
-    
 
     void SetUpMobility();
 


### PR DESCRIPTION
- When you have a RigidBody and you disable the component, the collider keeps moving even if the mesh do the expected behaviour