### PR TITLE
fix: UI Draw Hierarchy Recursive

### DIFF
--- a/Source/Modules/ModuleUI.cpp
+++ b/Source/Modules/ModuleUI.cpp
@@ -77,20 +77,9 @@ update_status ModuleUI::Update()
 
 	glDisable(GL_DEPTH_TEST);
 
-	for (ComponentCanvas* canvas : canvasScene)
+	for (const ComponentCanvas* canvas : canvasScene)
 	{
-		GameObject* owner = canvas->GetOwner();
-		if (owner->IsEnabled())
-		{
-			for (GameObject* child : owner->GetChildren())
-			{
-				//ugh, should look for a better way, but it's 2AM
-				for (ComponentImage* image : child->GetComponentsByType<ComponentImage>(ComponentType::IMAGE))
-				{
-					image->Draw();
-				}
-			}
-		}
+		Draw2DGameObject(canvas->GetOwner());
 	}
 
 	glEnable(GL_DEPTH_TEST);
@@ -169,4 +158,23 @@ void ModuleUI::CreateVAO()
 	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
 
 	glBindVertexArray(0);
+}
+
+void ModuleUI::Draw2DGameObject(const GameObject* gameObject)
+{
+	if (gameObject->IsEnabled())
+	{
+		for (const ComponentImage* image : gameObject->GetComponentsByType<ComponentImage>(ComponentType::IMAGE))
+		{
+			if(image->IsEnabled())
+			{
+				image->Draw();
+			}
+		}
+
+		for (const GameObject* child : gameObject->GetChildren())
+		{
+			Draw2DGameObject(child);
+		}
+	}
 }

--- a/Source/Modules/ModuleUI.h
+++ b/Source/Modules/ModuleUI.h
@@ -22,6 +22,8 @@ public:
 	unsigned int GetQuadVAO() const;
 
 private:
+	void Draw2DGameObject(const GameObject* gameObject);
+
 	unsigned int quadVBO;
 	unsigned int quadVAO;
 };


### PR DESCRIPTION
- UI draw hierarchy recursively
- Fix Enable bug: UI only check the canvas enable not the rest of the gameObjects, and ignore the Component enable.