### PR TITLE
Fix: Inspector Fixes and Copy RigidBody

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -131,6 +131,7 @@ void WindowInspector::InspectSelectedGameObject()
 {
 	ModuleScene* scene = App->GetModule<ModuleScene>();
 	Scene* loadedScene = scene->GetLoadedScene();
+
 	lastSelectedGameObject = scene->GetSelectedGameObject();
 
 	if (lastSelectedGameObject)
@@ -146,7 +147,7 @@ void WindowInspector::InspectSelectedGameObject()
 			{
 				std::string scene = " Scene";
 				std::string sceneName = name + scene;
-				lastSelectedGameObject->SetName(sceneName);
+				lastSelectedGameObject->SetName(sceneName.c_str());
 			}
 		}
 		else
@@ -154,7 +155,7 @@ void WindowInspector::InspectSelectedGameObject()
 			std::string name = lastSelectedGameObject->GetName();
 			if (ImGui::InputText("##GameObject", &name[0], 24))
 			{
-				lastSelectedGameObject->SetName(name);
+				lastSelectedGameObject->SetName(name.c_str());
 			}
 			ImGui::SameLine();
 			bool staticness = lastSelectedGameObject->IsStatic();
@@ -171,7 +172,7 @@ void WindowInspector::InspectSelectedGameObject()
 			tag.resize(24);
 			if (ImGui::InputText("##Tag", &tag[0], 24))
 			{
-				lastSelectedGameObject->SetTag(tag);
+				lastSelectedGameObject->SetTag(tag.c_str());
 			}
 		}
 

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -129,8 +129,8 @@ void WindowInspector::DrawWindowContents()
 
 void WindowInspector::InspectSelectedGameObject()
 {
-	ModuleScene* scene = App->GetModule<ModuleScene>();
-	Scene* loadedScene = scene->GetLoadedScene();
+	const ModuleScene* scene = App->GetModule<ModuleScene>();
+	const Scene* loadedScene = scene->GetLoadedScene();
 
 	if (lastSelectedGameObject != scene->GetSelectedGameObject())
 	{

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -151,7 +151,7 @@ void WindowInspector::InspectSelectedGameObject()
 		if (!lastSelectedGameObject->GetParent()) // Keep the word Scene in the root
 		{
 			std::string name = lastSelectedGameObject->GetName();
-			if (ImGui::InputText("##GameObject", &name[0], 24))
+			if (ImGui::InputText("##GameObject", &name[0], 32))
 			{
 				std::string scene = " Scene";
 				std::string sceneName = name + scene;
@@ -161,7 +161,7 @@ void WindowInspector::InspectSelectedGameObject()
 		else
 		{
 			std::string name = lastSelectedGameObject->GetName();
-			if (ImGui::InputText("##GameObject", &name[0], 24))
+			if (ImGui::InputText("##GameObject", &name[0], 32))
 			{
 				lastSelectedGameObject->SetName(name.c_str());
 			}
@@ -178,7 +178,7 @@ void WindowInspector::InspectSelectedGameObject()
 			ImGui::Text("Tag");
 			ImGui::SameLine();
 			tag.resize(24);
-			if (ImGui::InputText("##Tag", &tag[0], 24))
+			if (ImGui::InputText("##Tag", &tag[0], 32))
 			{
 				lastSelectedGameObject->SetTag(tag.c_str());
 			}

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -132,8 +132,16 @@ void WindowInspector::InspectSelectedGameObject()
 	ModuleScene* scene = App->GetModule<ModuleScene>();
 	Scene* loadedScene = scene->GetLoadedScene();
 
-	lastSelectedGameObject = scene->GetSelectedGameObject();
-
+	if (lastSelectedGameObject != scene->GetSelectedGameObject())
+	{
+		ImGui::PushID(1);
+		lastSelectedGameObject = scene->GetSelectedGameObject();
+	}
+	else
+	{
+		ImGui::PushID(0);
+	}
+	
 	if (lastSelectedGameObject)
 	{
 		bool enable = lastSelectedGameObject->IsEnabled();
@@ -236,6 +244,8 @@ void WindowInspector::InspectSelectedGameObject()
 		}
 		lastSelectedObjectUID = lastSelectedGameObject->GetUID();
 	}
+
+	ImGui::PopID();
 }
 
 void WindowInspector::InspectSelectedResource()


### PR DESCRIPTION
- Inspector thought that the InputText of the gameObject name was the same as the InputText of the last selected gameObject, so when you have the InputText selected and you delete the gameObject. The newly selected GameObject (the parent) is renamed to the name of the removed gameObject. ImGui is special
- Bug that does not allow to put a gameObject name longer than the one that already existed even if it did not exceed the maximum characters
- RigidBody CopyConstructor finished