### PR TITLE
fix/refactor: delay adding updatables to scene, deleting objects. GameObjects removed from scripts that reference them

### DIFF
--- a/Source/DataModels/Scene/Scene.h
+++ b/Source/DataModels/Scene/Scene.h
@@ -9,6 +9,8 @@
 #include "Components/ComponentPointLight.h"
 #include "Components/ComponentSpotLight.h"
 
+#include <queue>
+
 class Component;
 class ComponentCamera;
 class ComponentCanvas;
@@ -98,13 +100,16 @@ public:
 	void InitLights();
 
 	void InsertGameObjectAndChildrenIntoSceneGameObjects(GameObject* gameObject);
-	
+
 	void InitCubemap();
+
+	void ExecutePendingActions();
 
 private:
 	GameObject* FindRootBone(GameObject* node, const std::vector<Bone>& bones);
 	const std::vector<GameObject*> CacheBoneHierarchy(GameObject* gameObjectNode, const std::vector<Bone>& bones);
 	void RemoveFatherAndChildren(const GameObject* father);
+	void RemoveGameObjectFromScripts(const GameObject* gameObject);
 
 	std::unique_ptr<Skybox> skybox;
 	std::unique_ptr<Cubemap> cubemap;
@@ -130,6 +135,10 @@ private:
 	// Render Objects
 	std::unique_ptr<Quadtree> rootQuadtree;
 	std::vector<GameObject*> nonStaticObjects;
+
+	// All Updatable components should be added at the end of the frame to avoid modifying the iterated list
+	// Similarly, game objects should only be deleted at the end of the frame
+	std::queue<std::function<void(void)>> pendingCreateAndDeleteActions;
 };
 
 inline GameObject* Scene::GetRoot() const
@@ -219,5 +228,9 @@ inline void Scene::AddNonStaticObject(GameObject* gameObject)
 
 inline void Scene::AddUpdatableObject(Updatable* updatable)
 {
-	sceneUpdatableObjects.push_back(updatable);
+	pendingCreateAndDeleteActions.emplace(
+		[=]
+		{
+			sceneUpdatableObjects.push_back(updatable);
+		});
 }

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -157,6 +157,8 @@ update_status ModuleScene::PostUpdate()
 		sceneToLoad = "";
 	}
 
+	loadedScene->ExecutePendingActions();
+
 	return update_status::UPDATE_CONTINUE;
 }
 


### PR DESCRIPTION
As mentioned in the code, the method to remove the GameObject that is being deleted from the scripts turned out relatively complex. Tried my best to explain what it's doing with comments.