### PR TITLE
feat: overload array subscript operator in ModuleInput

### DIFF
--- a/Source/DataModels/Camera/Camera.cpp
+++ b/Source/DataModels/Camera/Camera.cpp
@@ -209,7 +209,7 @@ void Camera::KeyboardRotate()
 
 	ModuleInput* input = App->GetModule<ModuleInput>();
 
-	if (input->GetKey(SDL_SCANCODE_UP) != KeyState::IDLE)
+	if ((*input)[SDL_SCANCODE_UP] != KeyState::IDLE)
 	{
 		if (rotationAngle + rotationSpeed * acceleration < 180)
 			pitch = math::DegToRad(-DEFAULT_ROTATION_DEGREE);

--- a/Source/Modules/ModuleInput.h
+++ b/Source/Modules/ModuleInput.h
@@ -49,6 +49,8 @@ public:
 
 	bool IsMouseWheelScrolled() const;
 
+	KeyState operator[](SDL_Scancode index);
+
 private:
 	KeyState keysState[SDL_NUM_SCANCODES] = { KeyState::IDLE };
 	KeyState mouseButtonState[NUM_MOUSEBUTTONS] = { KeyState::IDLE };
@@ -172,4 +174,9 @@ inline void ModuleInput::SetShowCursor(bool set)
 inline bool ModuleInput::IsMouseWheelScrolled() const
 {
 	return mouseWheelScrolled;
+}
+
+inline KeyState ModuleInput::operator[](SDL_Scancode index)
+{
+	return keysState[index];
 }


### PR DESCRIPTION
Small QOL, we are able to replace calls like
```c++
input->GetKey(SDL_SCANCODE_UP)
```
for
```c++
(*input)[SDL_SCANCODE_UP]
```
Important to de-reference the pointer, otherwise we'd be calling the operator overload for pointer types, instead of the one in `ModuleInput`.
`GetKey` remains untouched, so this doesn't require any updates to pre-existing code.