### PR TITLE
feat: if no zip file exists, force user to create it

### DIFF
--- a/Source/DataModels/Windows/PopUpWindows/WindowBuild.cpp
+++ b/Source/DataModels/Windows/PopUpWindows/WindowBuild.cpp
@@ -88,7 +88,20 @@ void WindowBuild::DrawBuildTypeComboBox()
 
 void WindowBuild::DrawGenerateZipCheckbox()
 {
+	bool zipExists = App->GetModule<ModuleFileSystem>()->Exists("Assets.zip");
+	if (!zipExists)
+	{
+		ImGui::BeginDisabled();
+	}
 	ImGui::Checkbox("Generate a new assets zip file", &generateZip);
+	if (!zipExists)
+	{
+		if (ImGui::IsMouseHoveringRect(ImGui::GetItemRectMin(), ImGui::GetItemRectMax()))
+		{
+			ImGui::SetTooltip("Zip not found, one must be created");
+		}
+		ImGui::EndDisabled();
+	}
 }
 
 void WindowBuild::DrawBuildButton()


### PR DESCRIPTION
Basically disables the checkbox if the zip is not found. Necessary because not only you need one to run the game, the startup configuration also expects one, so we run into the risk of getting an error. Also added a tooltip to let the user know why the checkbox is disabled.