### PR TITLE
feat: add search bar to WindowHierarchy

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -52,13 +52,13 @@ void WindowHierarchy::DrawWindowContents()
 	lastSelectedGameObject = App->GetModule<ModuleScene>()->GetSelectedGameObject();
 }
 
-bool WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
+WindowHierarchy::DrawHierarchyResultCode WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 {
 	assert(gameObject);
 
 	if (!IsFiltered(gameObject))
 	{
-		return true;
+		return DrawHierarchyResultCode::ObjectNotFiltered;
 	}
 
 	ModuleScene* moduleScene = App->GetModule<ModuleScene>();
@@ -177,7 +177,7 @@ bool WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 			{
 				ImGui::TreePop();
 			}
-			return false;
+			return DrawHierarchyResultCode::HierarchyChanged;
 		}
 
 		ImGui::EndPopup();
@@ -229,7 +229,7 @@ bool WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 				{
 					ImGui::TreePop();
 				}
-				return false;
+				return DrawHierarchyResultCode::HierarchyChanged;
 			}
 		}
 
@@ -240,16 +240,16 @@ bool WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 	{
 		for (GameObject* child : children)
 		{
-			if (!DrawRecursiveHierarchy(child))
+			if (DrawRecursiveHierarchy(child) == DrawHierarchyResultCode::HierarchyChanged)
 			{
 				ImGui::TreePop();
-				return false;
+				return DrawHierarchyResultCode::HierarchyChanged;
 			}
 		}
 		ImGui::TreePop();
 	}
 
-	return true;
+	return DrawHierarchyResultCode::Success;
 }
 
 void WindowHierarchy::DrawSearchBar()

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -83,8 +83,10 @@ WindowHierarchy::DrawHierarchyResultCode WindowHierarchy::DrawRecursiveHierarchy
 		flags |= ImGuiTreeNodeFlags_Leaf;
 	}
 
-	if (gameObject->GetStateOfSelection() == StateOfSelection::CHILD_SELECTED &&
-		lastSelectedGameObject != App->GetModule<ModuleScene>()->GetSelectedGameObject())
+	bool ancestorOfSelectedObject = gameObject->GetStateOfSelection() == StateOfSelection::CHILD_SELECTED &&
+									lastSelectedGameObject != App->GetModule<ModuleScene>()->GetSelectedGameObject();
+	bool objectIsFiltered = !filteredObjects.empty();
+	if (ancestorOfSelectedObject || objectIsFiltered)
 	{
 		ImGui::SetNextItemOpen(true);
 	}

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -75,7 +75,9 @@ bool WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 	{
 		flags |= ImGuiTreeNodeFlags_DefaultOpen;
 	}
-	else if (children.empty())
+	else if (children.empty() || std::none_of(std::begin(children),
+											  std::end(children),
+											  std::bind(&WindowHierarchy::IsFiltered, this, std::placeholders::_1)))
 	{
 		flags |= ImGuiTreeNodeFlags_Leaf;
 	}

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -35,6 +35,7 @@ void WindowHierarchy::DrawWindowContents()
 	if (filteredObjects.count(0U) != 0)
 	{
 		ImGui::TextUnformatted("No Game Object with that name found in the scene");
+		return;
 	}
 
 	ImGui::Separator();

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
@@ -15,7 +15,13 @@ protected:
 	void DrawWindowContents() override;
 
 private:
-	bool DrawRecursiveHierarchy(GameObject* gameObject);
+	enum class DrawHierarchyResultCode
+	{
+		HierarchyChanged,
+		ObjectNotFiltered,
+		Success
+	};
+	DrawHierarchyResultCode DrawRecursiveHierarchy(GameObject* gameObject);
 	void DrawSearchBar();
 
 	void ProcessInput();

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "EditorWindow.h"
 
+#include "FileSystem/UID.h"
+
 class GameObject;
 
 class WindowHierarchy : public EditorWindow
@@ -14,7 +16,12 @@ protected:
 
 private:
 	bool DrawRecursiveHierarchy(GameObject* gameObject);
+	void DrawSearchBar();
+
 	void ProcessInput();
+
+	void SetUpFilter(const std::string& nameFilter);
+	bool IsFiltered(const GameObject* gameObject) const;
 
 	void Create2DObjectMenu(GameObject* gameObject);
 
@@ -35,4 +42,6 @@ private:
 
 	// this is the second time I add such a member, this should be standardized in a module
 	GameObject* lastSelectedGameObject;
+
+	std::unordered_set<UID> filteredObjects;
 };


### PR DESCRIPTION
- Filter game objects in the hierarchy, only draw those which's names contain the string written by the user.
- Filter is only set up when the search bar text changes, so we don't iterate the whole hierarchy each frame. When filter is set up, hierarchy is only traversed once (cost should be N).
- Use `unordered_set`, which according to the internet, is the most efficient container to use for searches.