### PR TITLE
fix: stop Bix movement and allow for the death screen to load

### DIFF
--- a/Game/Scripts/PlayerDeathScript.cpp
+++ b/Game/Scripts/PlayerDeathScript.cpp
@@ -38,7 +38,8 @@ void PlayerDeathScript::ManagePlayerDeath() const
 	{
 		LOG_VERBOSE("Player is dead");
 	}
-	//DisablePlayerActions();
+
+	DisablePlayerActions();
 }
 
 void PlayerDeathScript::DisablePlayerActions() const
@@ -48,7 +49,10 @@ void PlayerDeathScript::DisablePlayerActions() const
 
 	for (ComponentScript* script : gameObjectScripts)
 	{
-		script->Disable();
+		if (script->GetConstructName() != "PlayerDeathScript")
+		{
+			script->Disable();
+		}
 	}
 
 	GameObject::GameObjectView children = owner->GetChildren();


### PR DESCRIPTION
Now all the scripts that Bix has get disabled upon death except the one in charge of loading the death screen.