### PR TITLE
perf: GetComponents returns a C++20 view instead of a vector

### DIFF
--- a/Game/Scripts/EnemyDeathScript.cpp
+++ b/Game/Scripts/EnemyDeathScript.cpp
@@ -49,7 +49,7 @@ GameObject* EnemyDeathScript::RequestPowerUp() const
 void EnemyDeathScript::DisableEnemyActions() const
 {
 	// Once the player is dead, disable its scripts
-	std::vector<ComponentScript*> gameObjectScripts = owner->GetComponents<ComponentScript>();
+	GameObject::FilteredComponentView<ComponentScript> gameObjectScripts = owner->GetComponents<ComponentScript>();
 
 	for (ComponentScript* script : gameObjectScripts)
 	{

--- a/Game/Scripts/PlayerDeathScript.cpp
+++ b/Game/Scripts/PlayerDeathScript.cpp
@@ -44,7 +44,7 @@ void PlayerDeathScript::ManagePlayerDeath() const
 void PlayerDeathScript::DisablePlayerActions() const
 {
 	// Once the player is dead, disable its scripts
-	std::vector<ComponentScript*> gameObjectScripts = owner->GetComponents<ComponentScript>();
+	GameObject::FilteredComponentView<ComponentScript> gameObjectScripts = owner->GetComponents<ComponentScript>();
 
 	for (ComponentScript* script : gameObjectScripts)
 	{
@@ -63,7 +63,7 @@ void PlayerDeathScript::DisablePlayerActions() const
 			continue;
 		}
 
-		std::vector<ComponentScript*> cameraScripts = child->GetComponents<ComponentScript>();
+		GameObject::FilteredComponentView<ComponentScript> cameraScripts = child->GetComponents<ComponentScript>();
 
 		for (ComponentScript* script : cameraScripts)
 		{

--- a/Game/Scripts/UIButtonControl.cpp
+++ b/Game/Scripts/UIButtonControl.cpp
@@ -26,15 +26,7 @@ void UIButtonControl::Start()
 	
 	if (isGameResume != false)
 	{
-		std::vector<ComponentScript*> gameObjectScripts = setUiGameManagerObject->GetComponents<ComponentScript>();
-		for (int i = 0; i < gameObjectScripts.size(); ++i)
-		{
-			if (gameObjectScripts[i]->GetConstructName() == "UIGameManager")
-			{
-				UIGameManagerClass = static_cast<UIGameManager*>(gameObjectScripts[i]->GetScript());
-				break;
-			}
-		}
+		UIGameManagerClass = setUiGameManagerObject->GetComponent<UIGameManager>();
 	}
 }
 

--- a/Source/Auxiliar/Utils/View.h
+++ b/Source/Auxiliar/Utils/View.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <ranges>
+#include <vector>
+
+namespace axo
+{
+template<typename InnerView, typename FunctionArgument, typename FunctionReturn>
+using transform_view = std::ranges::transform_view<InnerView, std::function<FunctionReturn(const FunctionArgument&)>>;
+
+template<typename InnerView, typename FunctionArgument>
+using filter_view = std::ranges::filter_view<InnerView, std::function<bool(const FunctionArgument&)>>;
+
+template<typename Collection>
+using ref_view = std::ranges::ref_view<Collection>;
+
+template<typename ElementType>
+using ref_vector_view = ref_view<const std::vector<ElementType>>;
+
+template<typename PointerType>
+using ref_unique_vector_view = ref_vector_view<std::unique_ptr<PointerType>>;
+} // namespace axo

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -845,7 +845,7 @@ void GameObject::SpreadStatic()
 void GameObject::SetStatic(bool newStatic)
 {
 	staticObject = newStatic;
-	std::vector<ComponentRigidBody*> rigids = GetComponents<ComponentRigidBody>();
+	FilteredComponentView<ComponentRigidBody> rigids = GetComponents<ComponentRigidBody>();
 
 	for (ComponentRigidBody* rigid : rigids)
 	{

--- a/Source/DataModels/GameObject/GameObject.inl
+++ b/Source/DataModels/GameObject/GameObject.inl
@@ -54,7 +54,7 @@ template<typename S, std::enable_if_t<std::is_base_of<IScript, S>::value, bool>>
 S* GameObject::GetComponent()
 {
 	// GetComponents already makes sure the objects returned are not null
-	std::vector<ComponentScript*> componentScripts = GetComponents<ComponentScript>();
+	FilteredComponentView<ComponentScript> componentScripts = GetComponents<ComponentScript>();
 	auto componentWithScript = std::ranges::find_if(componentScripts,
 													[](const ComponentScript* component)
 													{
@@ -68,7 +68,7 @@ template<typename S, std::enable_if_t<std::is_base_of<IScript, S>::value, bool>>
 std::vector<S*> GameObject::GetComponents()
 {
 	// GetComponents already makes sure the objects returned are not null
-	std::vector<ComponentScript*> componentScripts = GetComponents<ComponentScript>();
+	FilteredComponentView<ComponentScript> componentScripts = GetComponents<ComponentScript>();
 	auto filteredScripts = componentScripts |
 						   std::views::transform(
 							   [](ComponentScript* component)

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -889,11 +889,11 @@ void Scene::UpdateScenePointLights()
 	{
 		if (child && child->IsActive())
 		{
-			std::vector<ComponentLight*> components = child->GetComponents<ComponentLight>();
-			if (!components.empty() && components[0]->GetLightType() == LightType::POINT && components[0]->IsEnabled())
+			GameObject::FilteredComponentView<ComponentLight> components = child->GetComponents<ComponentLight>();
+			if (!components.empty() && components.front()->GetLightType() == LightType::POINT && components.front()->IsEnabled())
 			{
-				ComponentPointLight* pointLightComp = static_cast<ComponentPointLight*>(components[0]);
-				ComponentTransform* transform = components[0]->GetOwner()->GetComponent<ComponentTransform>();
+				ComponentPointLight* pointLightComp = static_cast<ComponentPointLight*>(components.front());
+				ComponentTransform* transform = components.front()->GetOwner()->GetComponent<ComponentTransform>();
 
 				PointLight pl;
 				pl.position = float4(transform->GetGlobalPosition(), pointLightComp->GetRadius());
@@ -919,10 +919,10 @@ void Scene::UpdateSceneSpotLights()
 	{
 		if (child && child->IsActive())
 		{
-			std::vector<ComponentLight*> components = child->GetComponents<ComponentLight>();
-			if (!components.empty() && components[0]->GetLightType() == LightType::SPOT && components[0]->IsEnabled())
+			GameObject::FilteredComponentView<ComponentLight> components = child->GetComponents<ComponentLight>();
+			if (!components.empty() && components.front()->GetLightType() == LightType::SPOT && components.front()->IsEnabled())
 			{
-				ComponentSpotLight* spotLightComp = static_cast<ComponentSpotLight*>(components[0]);
+				ComponentSpotLight* spotLightComp = static_cast<ComponentSpotLight*>(components.front());
 				ComponentTransform* transform = child->GetComponent<ComponentTransform>();
 
 				SpotLight sl;
@@ -955,10 +955,10 @@ void Scene::UpdateSceneAreaLights()
 	{
 		if (child && child->IsActive())
 		{
-			std::vector<ComponentLight*> components = child->GetComponents<ComponentLight>();
-			if (!components.empty() && components[0]->GetLightType() == LightType::AREA && components[0]->IsEnabled())
+			GameObject::FilteredComponentView<ComponentLight> components = child->GetComponents<ComponentLight>();
+			if (!components.empty() && components.front()->GetLightType() == LightType::AREA && components.front()->IsEnabled())
 			{
-				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components[0]);
+				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components.front());
 				ComponentTransform* transform = child->GetComponent<ComponentTransform>();
 				if (areaLightComp->GetAreaType() == AreaType::SPHERE)
 				{
@@ -1013,10 +1013,10 @@ void Scene::UpdateSceneAreaSpheres()
 	{
 		if (child && child->IsActive())
 		{
-			std::vector<ComponentLight*> components = child->GetComponents<ComponentLight>();
-			if (!components.empty() && components[0]->GetLightType() == LightType::AREA && components[0]->IsEnabled())
+			GameObject::FilteredComponentView<ComponentLight> components = child->GetComponents<ComponentLight>();
+			if (!components.empty() && components.front()->GetLightType() == LightType::AREA && components.front()->IsEnabled())
 			{
-				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components[0]);
+				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components.front());
 				ComponentTransform* transform = child->GetComponent<ComponentTransform>();
 				if (areaLightComp->GetAreaType() == AreaType::SPHERE)
 				{
@@ -1049,10 +1049,10 @@ void Scene::UpdateSceneAreaTubes()
 	{
 		if (child && child->IsActive())
 		{
-			std::vector<ComponentLight*> components = child->GetComponents<ComponentLight>();
-			if (!components.empty() && components[0]->GetLightType() == LightType::AREA && components[0]->IsEnabled())
+			GameObject::FilteredComponentView<ComponentLight> components = child->GetComponents<ComponentLight>();
+			if (!components.empty() && components.front()->GetLightType() == LightType::AREA && components.front()->IsEnabled())
 			{
-				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components[0]);
+				ComponentAreaLight* areaLightComp = static_cast<ComponentAreaLight*>(components.front());
 				ComponentTransform* transform = child->GetComponent<ComponentTransform>();
 				if (areaLightComp->GetAreaType() == AreaType::TUBE)
 				{

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -799,6 +799,7 @@
     </ClInclude>
     <ClInclude Include="DataModels\Components\ComponentBreakable.h" />
     <ClInclude Include="DataModels\Components\ComponentCubemap.h" />
+    <ClInclude Include="Auxiliar\Utils\View.h" />
     <ClInclude Include="DataModels\Commands\Command.h" />
     <ClInclude Include="DataModels\Commands\CommandComponentEnabled.h" />
     <ClInclude Include="Auxiliar\CollectionAwareDeleter.h" />

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -1242,6 +1242,9 @@
     <ClInclude Include="..\Game\Scripts\AnimatedTexture.h">
       <Filter>UserScripts\Graphics</Filter>
     </ClInclude>
+    <ClInclude Include="Auxiliar\Utils\View.h">
+      <Filter>Auxiliar</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Auxiliar">

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -578,7 +578,7 @@ void ModuleRender::DrawHighlight(GameObject* gameObject)
 				gameObjectQueue.push(child);
 			}
 		}
-		std::vector<ComponentMeshRenderer*> meshes = currentGo->GetComponents<ComponentMeshRenderer>();
+		GameObject::FilteredComponentView<ComponentMeshRenderer> meshes = currentGo->GetComponents<ComponentMeshRenderer>();
 		
 		if (gameObjectsInFrustrum.find(currentGo) != gameObjectsInFrustrum.end())
 		{

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -397,7 +397,7 @@ void ModuleScene::LoadSceneFromJson(Json& json, bool mantainActualScene)
 
 	for (GameObject* obj : loadedObjects)
 	{
-		std::vector<ComponentCamera*> camerasOfObj = obj->GetComponents<ComponentCamera>();
+		auto camerasOfObj = obj->GetComponents<ComponentCamera>();
 		loadedCameras.insert(std::end(loadedCameras), std::begin(camerasOfObj), std::end(camerasOfObj));
 
 		ComponentCanvas* canvas = obj->GetComponent<ComponentCanvas>();
@@ -416,7 +416,7 @@ void ModuleScene::LoadSceneFromJson(Json& json, bool mantainActualScene)
 			loadedParticle.push_back(static_cast<ComponentParticleSystem*>(particle));
 		}
 
-		std::vector<ComponentLight*> lightsOfObj = obj->GetComponents<ComponentLight>();
+		GameObject::FilteredComponentView<ComponentLight> lightsOfObj = obj->GetComponents<ComponentLight>();
 		for (const ComponentLight* light : lightsOfObj)
 		{
 			if (light->GetLightType() == LightType::DIRECTIONAL)


### PR DESCRIPTION
I chose to leave the scripts' versions of `GetComponents` as is, so it still returns a vector. I feel like it's easier to use for the gameplay team that way, and it's not like it's a big improvement in performance anyway.