### PR TITLE
Feat: Entity Detection and linked with Bix Attack

### DIFF
--- a/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
@@ -174,9 +174,9 @@
                             "type": "Component_Transform",
                             "active": true,
                             "removed": false,
-                            "localPos_X": 5.567686080932617,
-                            "localPos_Y": 1.5957939624786377,
-                            "localPos_Z": -7.999545097351074,
+                            "localPos_X": 28.469329833984375,
+                            "localPos_Y": 1.595918893814087,
+                            "localPos_Z": -26.125856399536133,
                             "localRot_X": 0.0,
                             "localRot_Y": 0.0,
                             "localRot_Z": 0.0,
@@ -220,9 +220,9 @@
                             "radius": 3.464101552963257,
                             "factor": 0.5,
                             "height": 2.0,
-                            "rbPos_X": 5.567686080932617,
-                            "rbPos_Y": 1.5957939624786377,
-                            "rbPos_Z": -7.999545097351074
+                            "rbPos_X": 28.469329833984375,
+                            "rbPos_Y": 1.595918893814087,
+                            "rbPos_Z": -26.125856399536133
                         }
                     }
                 ]
@@ -343,6 +343,11 @@
                                     "name": "BulletVelocity",
                                     "value": 0.20000000298023224,
                                     "type": 0
+                                },
+                                {
+                                    "name": "LaserParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -368,6 +373,11 @@
                                     "name": "IsImmortal",
                                     "value": false,
                                     "type": 4
+                                },
+                                {
+                                    "name": "EnemyParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -386,7 +396,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": false,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -3276,6 +3286,11 @@
                                     "name": "BulletVelocity",
                                     "value": 0.20000000298023224,
                                     "type": 0
+                                },
+                                {
+                                    "name": "LaserParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -3301,6 +3316,11 @@
                                     "name": "IsImmortal",
                                     "value": false,
                                     "type": 4
+                                },
+                                {
+                                    "name": "EnemyParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -3319,7 +3339,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": false,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -6126,9 +6146,9 @@
                             "radius": 1.2999999523162842,
                             "factor": 0.5,
                             "height": 2.0,
-                            "rbPos_X": -7.840948581695557,
+                            "rbPos_X": -21.034690856933594,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -23.908191680908203
                         }
                     },
                     {
@@ -6209,9 +6229,9 @@
                             "radius": 1.2999999523162842,
                             "factor": 0.5,
                             "height": 2.0,
-                            "rbPos_X": -4.359014987945557,
+                            "rbPos_X": -17.552757263183594,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_Z": -23.846397399902344
                         }
                     },
                     {
@@ -6246,9 +6266,9 @@
                             "type": "Component_Transform",
                             "active": true,
                             "removed": false,
-                            "localPos_X": 0.0,
+                            "localPos_X": -13.193742752075195,
                             "localPos_Y": 0.0,
-                            "localPos_Z": 0.0,
+                            "localPos_Z": -15.14533519744873,
                             "localRot_X": 0.0,
                             "localRot_Y": 0.0,
                             "localRot_Z": 0.0,
@@ -6508,7 +6528,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": true,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -6585,7 +6605,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": true,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -6700,7 +6720,7 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.6499999761581421,
-                            "rbPos_Z": -14.259493827819824
+                            "rbPos_Z": -14.258999824523926
                         }
                     },
                     {
@@ -6729,27 +6749,27 @@
                                 },
                                 {
                                     "name": "AnimationGO",
-                                    "value": 1326767777895378518,
+                                    "value": 0,
                                     "type": 2
                                 },
                                 {
                                     "name": "Ray1GO",
-                                    "value": 14570301510423466673,
+                                    "value": 0,
                                     "type": 2
                                 },
                                 {
                                     "name": "Ray2GO",
-                                    "value": 5452242269074380210,
+                                    "value": 0,
                                     "type": 2
                                 },
                                 {
                                     "name": "Ray3GO",
-                                    "value": 5589610362906401601,
+                                    "value": 0,
                                     "type": 2
                                 },
                                 {
                                     "name": "Ray4GO",
-                                    "value": 12222878279298388583,
+                                    "value": 0,
                                     "type": 2
                                 }
                             ]
@@ -6776,6 +6796,11 @@
                                     "name": "IsImmortal",
                                     "value": false,
                                     "type": 4
+                                },
+                                {
+                                    "name": "EnemyParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -12861,7 +12886,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": false,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -12974,6 +12999,11 @@
                                     "name": "BulletVelocity",
                                     "value": 0.20000000298023224,
                                     "type": 0
+                                },
+                                {
+                                    "name": "LaserParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -12999,6 +13029,11 @@
                                     "name": "IsImmortal",
                                     "value": false,
                                     "type": 4
+                                },
+                                {
+                                    "name": "EnemyParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -16422,9 +16457,9 @@
                             "radius": 1.2999999523162842,
                             "factor": 0.5,
                             "height": 2.0,
-                            "rbPos_X": -7.840948581695557,
+                            "rbPos_X": -21.034690856933594,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -23.908191680908203
                         }
                     },
                     {
@@ -16459,9 +16494,9 @@
                             "type": "Component_Transform",
                             "active": true,
                             "removed": false,
-                            "localPos_X": -4.359014987945557,
-                            "localPos_Y": 3.2121219635009766,
-                            "localPos_Z": -8.701062202453613,
+                            "localPos_X": -4.330829620361328,
+                            "localPos_Y": 3.2121224403381348,
+                            "localPos_Z": -8.74808406829834,
                             "localRot_X": -0.0,
                             "localRot_Y": 0.0,
                             "localRot_Z": -0.0,
@@ -16505,9 +16540,9 @@
                             "radius": 1.2999999523162842,
                             "factor": 0.5,
                             "height": 2.0,
-                            "rbPos_X": -4.359014987945557,
-                            "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_X": -17.524572372436523,
+                            "rbPos_Y": 3.2121224403381348,
+                            "rbPos_Z": -23.89341926574707
                         }
                     },
                     {
@@ -16790,7 +16825,7 @@
                             "removed": true,
                             "isKinematic": false,
                             "isTrigger": false,
-                            "drawCollider": true,
+                            "drawCollider": false,
                             "mass": 100.0,
                             "linearDamping": 0.10000000149011612,
                             "angularDamping": 0.10000000149011612,
@@ -16903,6 +16938,11 @@
                                     "name": "BulletVelocity",
                                     "value": 0.20000000298023224,
                                     "type": 0
+                                },
+                                {
+                                    "name": "LaserParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -16928,6 +16968,11 @@
                                     "name": "IsImmortal",
                                     "value": false,
                                     "type": 4
+                                },
+                                {
+                                    "name": "EnemyParticleSystem",
+                                    "value": 0,
+                                    "type": 2
                                 }
                             ]
                         }
@@ -20292,10 +20337,10 @@
                             "localAABB_min_y": 0.0,
                             "localAABB_max_x": 0.0,
                             "localAABB_max_y": 0.0,
-                            "worldAABB_min_x": 836.5,
-                            "worldAABB_min_y": 567.5,
-                            "worldAABB_max_x": 836.5,
-                            "worldAABB_max_y": 567.5
+                            "worldAABB_min_x": 421.5,
+                            "worldAABB_min_y": 308.0,
+                            "worldAABB_max_x": 421.5,
+                            "worldAABB_max_y": 308.0
                         }
                     },
                     {
@@ -20387,10 +20432,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20426,9 +20471,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 96.96875,
-                            "worldAABB_max_x": 1673.0,
-                            "worldAABB_max_y": 1038.03125
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20478,10 +20523,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20516,10 +20561,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20554,10 +20599,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20593,9 +20638,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 96.96875,
-                            "worldAABB_max_x": 1673.0,
-                            "worldAABB_max_y": 1038.03125
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20645,10 +20690,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20684,9 +20729,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 96.96875,
-                            "worldAABB_max_x": 1673.0,
-                            "worldAABB_max_y": 1038.03125
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20736,10 +20781,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20774,10 +20819,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 686.19140625,
-                            "worldAABB_min_y": 335.8530578613281,
-                            "worldAABB_max_x": 986.80859375,
-                            "worldAABB_max_y": 410.3538513183594
+                            "worldAABB_min_x": 345.76171875,
+                            "worldAABB_min_y": 191.27651977539063,
+                            "worldAABB_max_x": 497.23828125,
+                            "worldAABB_max_y": 228.81637573242188
                         }
                     },
                     {
@@ -20827,10 +20872,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 479.97625732421875,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 550.1203002929688
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 263.8980712890625,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 299.24261474609375
                         }
                     },
                     {
@@ -20952,10 +20997,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 567.7320556640625,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 637.8760986328125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 308.1169128417969,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 343.4614562988281
                         }
                     },
                     {
@@ -21077,10 +21122,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21115,10 +21160,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21153,10 +21198,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 655.4878540039063,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 725.6318969726563
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 352.3357849121094,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 387.6803283691406
                         }
                     },
                     {
@@ -21278,10 +21323,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 743.24365234375,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 813.3876953125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 396.55462646484375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 431.899169921875
                         }
                     },
                     {
@@ -21403,10 +21448,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 479.976318359375,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 550.120361328125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 263.89813232421875,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 299.24267578125
                         }
                     },
                     {
@@ -21456,10 +21501,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 567.7320556640625,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 637.8760986328125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 308.116943359375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 343.46148681640625
                         }
                     },
                     {
@@ -21509,10 +21554,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 655.4878540039063,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 725.6318969726563
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 352.3357849121094,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 387.6803283691406
                         }
                     },
                     {
@@ -21562,10 +21607,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 720.39208984375,
-                            "worldAABB_min_y": 743.24365234375,
-                            "worldAABB_max_x": 952.60791015625,
-                            "worldAABB_max_y": 813.3876953125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 396.55462646484375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 431.899169921875
                         }
                     },
                     {
@@ -21615,10 +21660,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21654,9 +21699,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 96.96875,
-                            "worldAABB_max_x": 1673.0,
-                            "worldAABB_max_y": 1038.03125
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -21706,10 +21751,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1416.0535888671875,
-                            "worldAABB_min_y": 149.8080291748047,
-                            "worldAABB_max_x": 1513.6451416015625,
-                            "worldAABB_max_y": 174.20594787597656
+                            "worldAABB_min_x": 713.5284423828125,
+                            "worldAABB_min_y": 97.53118133544922,
+                            "worldAABB_max_x": 762.7034912109375,
+                            "worldAABB_max_y": 109.8249282836914
                         }
                     },
                     {
@@ -21832,9 +21877,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 96.96875,
-                            "worldAABB_max_x": 1673.0,
-                            "worldAABB_max_y": 1038.03125
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -21884,10 +21929,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21922,10 +21967,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21960,10 +22005,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 20.43262481689453,
-                            "worldAABB_min_y": 210.05751037597656,
-                            "worldAABB_max_x": 274.432373046875,
-                            "worldAABB_max_y": 283.68695068359375
+                            "worldAABB_min_x": 10.295703887939453,
+                            "worldAABB_min_y": 127.89000701904297,
+                            "worldAABB_max_x": 138.2824249267578,
+                            "worldAABB_max_y": 164.99078369140625
                         }
                     },
                     {
@@ -22013,10 +22058,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1694.9722900390625,
-                            "worldAABB_min_y": 136.61538696289063,
-                            "worldAABB_max_x": 2194.69384765625,
-                            "worldAABB_max_y": 271.6752624511719
+                            "worldAABB_min_x": 854.071533203125,
+                            "worldAABB_min_y": 90.88359069824219,
+                            "worldAABB_max_x": 1105.8739013671875,
+                            "worldAABB_max_y": 158.9382781982422
                         }
                     },
                     {
@@ -22024,8 +22069,8 @@
                             "type": "Component_Image",
                             "active": true,
                             "removed": true,
-                            "imageUID": 15732540000650079517,
-                            "assetPathImage": "Assets/Textures/UI_HUD_Mission_01.png",
+                            "imageUID": 0,
+                            "assetPathImage": "",
                             "color_x": 1.0,
                             "color_y": 1.0,
                             "color_z": 1.0,
@@ -22083,10 +22128,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 117.4916000366211,
-                            "worldAABB_min_y": 72.72545623779297,
-                            "worldAABB_max_x": 291.7624206542969,
-                            "worldAABB_max_y": 246.99627685546875
+                            "worldAABB_min_x": 59.2022705078125,
+                            "worldAABB_min_y": 58.69041442871094,
+                            "worldAABB_max_x": 147.0147705078125,
+                            "worldAABB_max_y": 146.50291442871094
                         }
                     },
                     {
@@ -22135,10 +22180,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 19.682098388671875,
-                            "worldAABB_min_y": 107.36178588867188,
-                            "worldAABB_max_x": 389.5719299316406,
-                            "worldAABB_max_y": 212.35995483398438
+                            "worldAABB_min_x": 9.917503356933594,
+                            "worldAABB_min_y": 76.14315032958984,
+                            "worldAABB_max_x": 196.29953002929688,
+                            "worldAABB_max_y": 129.05018615722656
                         }
                     },
                     {
@@ -22188,10 +22233,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 171.4840087890625,
-                            "worldAABB_min_y": 169.09132385253906,
-                            "worldAABB_max_x": 361.439208984375,
-                            "worldAABB_max_y": 186.51841735839844
+                            "worldAABB_min_x": 86.40826416015625,
+                            "worldAABB_min_y": 107.24775695800781,
+                            "worldAABB_max_x": 182.1239013671875,
+                            "worldAABB_max_y": 116.02900695800781
                         }
                     },
                     {
@@ -22241,10 +22286,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 377.21331787109375,
-                            "worldAABB_min_y": 133.72024536132813,
-                            "worldAABB_max_x": 398.9971923828125,
-                            "worldAABB_max_y": 186.00149536132813
+                            "worldAABB_min_x": 190.0722198486328,
+                            "worldAABB_min_y": 89.42478942871094,
+                            "worldAABB_max_x": 201.0487823486328,
+                            "worldAABB_max_y": 115.76853942871094
                         }
                     },
                     {
@@ -22310,10 +22355,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 117.49166107177734,
-                            "worldAABB_min_y": 72.72505950927734,
-                            "worldAABB_max_x": 291.7624816894531,
-                            "worldAABB_max_y": 246.99588012695313
+                            "worldAABB_min_x": 59.202301025390625,
+                            "worldAABB_min_y": 58.690216064453125,
+                            "worldAABB_max_x": 147.01480102539063,
+                            "worldAABB_max_y": 146.50271606445313
                         }
                     },
                     {
@@ -22362,10 +22407,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 30.356246948242188,
-                            "worldAABB_min_y": 138.0766143798828,
-                            "worldAABB_max_x": 378.89788818359375,
-                            "worldAABB_max_y": 181.6443328857422
+                            "worldAABB_min_x": 15.296051025390625,
+                            "worldAABB_min_y": 91.61990356445313,
+                            "worldAABB_max_x": 190.92105102539063,
+                            "worldAABB_max_y": 113.57302856445313
                         }
                     },
                     {
@@ -22415,10 +22460,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 171.4842529296875,
-                            "worldAABB_min_y": 169.09071350097656,
-                            "worldAABB_max_x": 361.439453125,
-                            "worldAABB_max_y": 186.51780700683594
+                            "worldAABB_min_x": 86.40835571289063,
+                            "worldAABB_min_y": 107.24745178222656,
+                            "worldAABB_max_x": 182.12399291992188,
+                            "worldAABB_max_y": 116.02870178222656
                         }
                     },
                     {
@@ -22468,10 +22513,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 366.6795349121094,
-                            "worldAABB_min_y": 133.7198486328125,
-                            "worldAABB_max_x": 388.4634094238281,
-                            "worldAABB_max_y": 186.0010986328125
+                            "worldAABB_min_x": 184.764404296875,
+                            "worldAABB_min_y": 89.42459106445313,
+                            "worldAABB_max_x": 195.740966796875,
+                            "worldAABB_max_y": 115.76834106445313
                         }
                     },
                     {
@@ -22537,10 +22582,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 749.3645629882813,
-                            "worldAABB_min_y": 480.3645935058594,
-                            "worldAABB_max_x": 923.6354370117188,
-                            "worldAABB_max_y": 654.6354370117188
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -22575,10 +22620,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1327.9437255859375,
-                            "worldAABB_min_y": 811.4791870117188,
-                            "worldAABB_max_x": 1502.2144775390625,
-                            "worldAABB_max_y": 985.7500610351563
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -22627,10 +22672,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22680,10 +22725,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22733,10 +22778,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1404.1871337890625,
-                            "worldAABB_min_y": 872.4739990234375,
-                            "worldAABB_max_x": 1425.9710693359375,
-                            "worldAABB_max_y": 924.7552490234375
+                            "worldAABB_min_x": 707.5491943359375,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 718.5257568359375,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -22802,10 +22847,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1327.9437255859375,
-                            "worldAABB_min_y": 811.4791870117188,
-                            "worldAABB_max_x": 1502.2144775390625,
-                            "worldAABB_max_y": 985.7500610351563
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -22854,10 +22899,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22907,10 +22952,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22960,10 +23005,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1505.64111328125,
-                            "worldAABB_min_y": 872.4739990234375,
-                            "worldAABB_max_x": 1527.425048828125,
-                            "worldAABB_max_y": 924.7552490234375
+                            "worldAABB_min_x": 758.67041015625,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 769.64697265625,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23029,10 +23074,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1327.9437255859375,
-                            "worldAABB_min_y": 811.4791870117188,
-                            "worldAABB_max_x": 1502.2144775390625,
-                            "worldAABB_max_y": 985.7500610351563
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -23081,10 +23126,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23134,10 +23179,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23187,10 +23232,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1506.2884521484375,
-                            "worldAABB_min_y": 872.4739990234375,
-                            "worldAABB_max_x": 1528.0723876953125,
-                            "worldAABB_max_y": 924.7552490234375
+                            "worldAABB_min_x": 758.9965209960938,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 769.9730834960938,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23256,10 +23301,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1327.9437255859375,
-                            "worldAABB_min_y": 811.4791870117188,
-                            "worldAABB_max_x": 1502.2144775390625,
-                            "worldAABB_max_y": 985.7500610351563
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -23308,10 +23353,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23361,10 +23406,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1312.25927734375,
-                            "worldAABB_min_y": 795.7947998046875,
-                            "worldAABB_max_x": 1517.89892578125,
-                            "worldAABB_max_y": 1001.4344482421875
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23414,10 +23459,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 1574.381103515625,
-                            "worldAABB_min_y": 872.4739990234375,
-                            "worldAABB_max_x": 1596.1650390625,
-                            "worldAABB_max_y": 924.7552490234375
+                            "worldAABB_min_x": 793.3074340820313,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 804.2839965820313,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23449,6 +23494,83 @@
                             "colorClicked_z": 0.5,
                             "colorClicked_w": 1.0,
                             "sceneName": ""
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "EnemyDetection",
+                "tag": "",
+                "uid": 8746673805549693416,
+                "parentUID": 1326767777895378518,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 0.0,
+                            "localPos_Z": 0.0,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 1.0,
+                            "localSca_Y": 1.0,
+                            "localSca_Z": 1.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_RigidBody",
+                            "active": true,
+                            "removed": true,
+                            "isKinematic": false,
+                            "isTrigger": true,
+                            "drawCollider": true,
+                            "mass": 100.0,
+                            "linearDamping": 0.10000000149011612,
+                            "angularDamping": 0.10000000149011612,
+                            "restitution": 0.0,
+                            "currentShape": 2,
+                            "usePositionController": false,
+                            "useRotationController": false,
+                            "KpForce": 5.0,
+                            "KpTorque": 0.05000000074505806,
+                            "gravity_Y": -9.8100004196167,
+                            "boxSize_X": 0.0,
+                            "boxSize_Y": 0.0,
+                            "boxSize_Z": 0.0,
+                            "radius": 8.0,
+                            "factor": 0.5,
+                            "height": 2.0,
+                            "rbPos_X": 0.0,
+                            "rbPos_Y": -0.5,
+                            "rbPos_Z": -14.25
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Script",
+                            "active": true,
+                            "removed": true,
+                            "constructName": "EntityDetection",
+                            "fields": [
+                                {
+                                    "name": "Player",
+                                    "value": 1326767777895378518,
+                                    "type": 2
+                                },
+                                {
+                                    "name": "InteractionAngle",
+                                    "value": 50.0,
+                                    "type": 0
+                                }
+                            ]
                         }
                     }
                 ]

--- a/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
@@ -6757,33 +6757,13 @@
                                     "type": 0
                                 },
                                 {
-                                    "name": "RayAttackSize",
-                                    "value": 10.0,
-                                    "type": 0
-                                },
-                                {
                                     "name": "AnimationGO",
                                     "value": 1326767777895378518,
                                     "type": 2
                                 },
                                 {
-                                    "name": "Ray1GO",
-                                    "value": 14570301510423466673,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray2GO",
-                                    "value": 5452242269074380210,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray3GO",
-                                    "value": 5589610362906401601,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray4GO",
-                                    "value": 12222878279298388583,
+                                    "name": "EnemyDetectionObject",
+                                    "value": 12448675388407140002,
                                     "type": 2
                                 }
                             ]
@@ -20351,10 +20331,10 @@
                             "localAABB_min_y": 0.0,
                             "localAABB_max_x": 0.0,
                             "localAABB_max_y": 0.0,
-                            "worldAABB_min_x": 385.0,
-                            "worldAABB_min_y": 243.0,
-                            "worldAABB_max_x": 385.0,
-                            "worldAABB_max_y": 243.0
+                            "worldAABB_min_x": 421.5,
+                            "worldAABB_min_y": 308.0,
+                            "worldAABB_max_x": 421.5,
+                            "worldAABB_max_y": 308.0
                         }
                     },
                     {
@@ -20446,10 +20426,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20485,9 +20465,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 26.4375,
-                            "worldAABB_max_x": 770.0,
-                            "worldAABB_max_y": 459.5625
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20537,10 +20517,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20575,10 +20555,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20613,10 +20593,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20652,9 +20632,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 26.4375,
-                            "worldAABB_max_x": 770.0,
-                            "worldAABB_max_y": 459.5625
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20704,10 +20684,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20743,9 +20723,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 26.4375,
-                            "worldAABB_max_x": 770.0,
-                            "worldAABB_max_y": 459.5625
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -20795,10 +20775,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -20833,10 +20813,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 315.8203125,
-                            "worldAABB_min_y": 136.38424682617188,
-                            "worldAABB_max_x": 454.1796875,
-                            "worldAABB_max_y": 170.67330932617188
+                            "worldAABB_min_x": 345.76171875,
+                            "worldAABB_min_y": 191.27651977539063,
+                            "worldAABB_max_x": 497.23828125,
+                            "worldAABB_max_y": 228.81637573242188
                         }
                     },
                     {
@@ -20886,10 +20866,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 202.7171173095703,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 235.00096130371094
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 263.8980712890625,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 299.24261474609375
                         }
                     },
                     {
@@ -21011,10 +20991,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 243.10682678222656,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 275.39068603515625
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 308.1169128417969,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 343.4614562988281
                         }
                     },
                     {
@@ -21136,10 +21116,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21174,10 +21154,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21212,10 +21192,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 283.4964904785156,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 315.7803649902344
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 352.3357849121094,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 387.6803283691406
                         }
                     },
                     {
@@ -21337,10 +21317,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 323.88616943359375,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 356.1700439453125
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 396.55462646484375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 431.899169921875
                         }
                     },
                     {
@@ -21462,10 +21442,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 202.71714782714844,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 235.00099182128906
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 263.89813232421875,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 299.24267578125
                         }
                     },
                     {
@@ -21515,10 +21495,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 243.10682678222656,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 275.39068603515625
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 308.116943359375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 343.46148681640625
                         }
                     },
                     {
@@ -21568,10 +21548,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 283.4964904785156,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 315.7803649902344
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 352.3357849121094,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 387.6803283691406
                         }
                     },
                     {
@@ -21621,10 +21601,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 331.5611877441406,
-                            "worldAABB_min_y": 323.8861999511719,
-                            "worldAABB_max_x": 438.4388122558594,
-                            "worldAABB_max_y": 356.1700744628906
+                            "worldAABB_min_x": 362.99493408203125,
+                            "worldAABB_min_y": 396.55462646484375,
+                            "worldAABB_max_x": 480.00506591796875,
+                            "worldAABB_max_y": 431.899169921875
                         }
                     },
                     {
@@ -21674,10 +21654,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21713,9 +21693,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 26.4375,
-                            "worldAABB_max_x": 770.0,
-                            "worldAABB_max_y": 459.5625
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -21765,10 +21745,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 651.7401123046875,
-                            "worldAABB_min_y": 50.756832122802734,
-                            "worldAABB_max_x": 696.65673828125,
-                            "worldAABB_max_y": 61.98599624633789
+                            "worldAABB_min_x": 713.5284423828125,
+                            "worldAABB_min_y": 97.53118133544922,
+                            "worldAABB_max_x": 762.7034912109375,
+                            "worldAABB_max_y": 109.8249282836914
                         }
                     },
                     {
@@ -21891,9 +21871,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 26.4375,
-                            "worldAABB_max_x": 770.0,
-                            "worldAABB_max_y": 459.5625
+                            "worldAABB_min_y": 70.90625,
+                            "worldAABB_max_x": 843.0,
+                            "worldAABB_max_y": 545.09375
                         }
                     },
                     {
@@ -21943,10 +21923,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -21981,10 +21961,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -22019,10 +21999,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 9.404136657714844,
-                            "worldAABB_min_y": 78.4867172241211,
-                            "worldAABB_max_x": 126.30777740478516,
-                            "worldAABB_max_y": 112.3747329711914
+                            "worldAABB_min_x": 10.295703887939453,
+                            "worldAABB_min_y": 127.89000701904297,
+                            "worldAABB_max_x": 138.2824249267578,
+                            "worldAABB_max_y": 164.99078369140625
                         }
                     },
                     {
@@ -22072,10 +22052,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 780.1127319335938,
-                            "worldAABB_min_y": 44.684898376464844,
-                            "worldAABB_max_x": 1010.1101684570313,
-                            "worldAABB_max_y": 106.84635162353516
+                            "worldAABB_min_x": 854.071533203125,
+                            "worldAABB_min_y": 90.88359069824219,
+                            "worldAABB_max_x": 1105.8739013671875,
+                            "worldAABB_max_y": 158.9382781982422
                         }
                     },
                     {
@@ -22142,10 +22122,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 54.075645446777344,
-                            "worldAABB_min_y": 15.279502868652344,
-                            "worldAABB_max_x": 134.28396606445313,
-                            "worldAABB_max_y": 95.48783111572266
+                            "worldAABB_min_x": 59.2022705078125,
+                            "worldAABB_min_y": 58.69041442871094,
+                            "worldAABB_max_x": 147.0147705078125,
+                            "worldAABB_max_y": 146.50291442871094
                         }
                     },
                     {
@@ -22194,10 +22174,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 9.0587158203125,
-                            "worldAABB_min_y": 31.22090721130371,
-                            "worldAABB_max_x": 179.3009033203125,
-                            "worldAABB_max_y": 79.54642486572266
+                            "worldAABB_min_x": 9.917503356933594,
+                            "worldAABB_min_y": 76.14315032958984,
+                            "worldAABB_max_x": 196.29953002929688,
+                            "worldAABB_max_y": 129.05018615722656
                         }
                     },
                     {
@@ -22247,10 +22227,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 78.92571258544922,
-                            "worldAABB_min_y": 59.63199234008789,
-                            "worldAABB_max_x": 166.352783203125,
-                            "worldAABB_max_y": 67.65282440185547
+                            "worldAABB_min_x": 86.40826416015625,
+                            "worldAABB_min_y": 107.24775695800781,
+                            "worldAABB_max_x": 182.1239013671875,
+                            "worldAABB_max_y": 116.02900695800781
                         }
                     },
                     {
@@ -22300,10 +22280,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 173.6128387451172,
-                            "worldAABB_min_y": 43.3524169921875,
-                            "worldAABB_max_x": 183.6388702392578,
-                            "worldAABB_max_y": 67.4149169921875
+                            "worldAABB_min_x": 190.0722198486328,
+                            "worldAABB_min_y": 89.42478942871094,
+                            "worldAABB_max_x": 201.0487823486328,
+                            "worldAABB_max_y": 115.76853942871094
                         }
                     },
                     {
@@ -22369,10 +22349,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 54.07567596435547,
-                            "worldAABB_min_y": 15.279319763183594,
-                            "worldAABB_max_x": 134.28399658203125,
-                            "worldAABB_max_y": 95.4876480102539
+                            "worldAABB_min_x": 59.202301025390625,
+                            "worldAABB_min_y": 58.690216064453125,
+                            "worldAABB_max_x": 147.01480102539063,
+                            "worldAABB_max_y": 146.50271606445313
                         }
                     },
                     {
@@ -22421,10 +22401,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 13.971511840820313,
-                            "worldAABB_min_y": 45.357444763183594,
-                            "worldAABB_max_x": 174.38816833496094,
-                            "worldAABB_max_y": 65.4095230102539
+                            "worldAABB_min_x": 15.296051025390625,
+                            "worldAABB_min_y": 91.61990356445313,
+                            "worldAABB_max_x": 190.92105102539063,
+                            "worldAABB_max_y": 113.57302856445313
                         }
                     },
                     {
@@ -22474,10 +22454,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 78.9258041381836,
-                            "worldAABB_min_y": 59.631717681884766,
-                            "worldAABB_max_x": 166.35287475585938,
-                            "worldAABB_max_y": 67.65254974365234
+                            "worldAABB_min_x": 86.40835571289063,
+                            "worldAABB_min_y": 107.24745178222656,
+                            "worldAABB_max_x": 182.12399291992188,
+                            "worldAABB_max_y": 116.02870178222656
                         }
                     },
                     {
@@ -22527,10 +22507,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 168.7646484375,
-                            "worldAABB_min_y": 43.35223388671875,
-                            "worldAABB_max_x": 178.79067993164063,
-                            "worldAABB_max_y": 67.41473388671875
+                            "worldAABB_min_x": 184.764404296875,
+                            "worldAABB_min_y": 89.42459106445313,
+                            "worldAABB_max_x": 195.740966796875,
+                            "worldAABB_max_y": 115.76834106445313
                         }
                     },
                     {
@@ -22596,10 +22576,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 344.8958435058594,
-                            "worldAABB_min_y": 202.89584350585938,
-                            "worldAABB_max_x": 425.1041564941406,
-                            "worldAABB_max_y": 283.1041564941406
+                            "worldAABB_min_x": 377.59375,
+                            "worldAABB_min_y": 264.09375,
+                            "worldAABB_max_x": 465.40625,
+                            "worldAABB_max_y": 351.90625
                         }
                     }
                 ]
@@ -22634,10 +22614,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 611.1874389648438,
-                            "worldAABB_min_y": 355.2916564941406,
-                            "worldAABB_max_x": 691.3958129882813,
-                            "worldAABB_max_y": 435.4999694824219
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -22686,10 +22666,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22739,10 +22719,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22792,10 +22772,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 646.2786254882813,
-                            "worldAABB_min_y": 383.36456298828125,
-                            "worldAABB_max_x": 656.3046264648438,
-                            "worldAABB_max_y": 407.42706298828125
+                            "worldAABB_min_x": 707.5491943359375,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 718.5257568359375,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -22861,10 +22841,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 611.1874389648438,
-                            "worldAABB_min_y": 355.2916564941406,
-                            "worldAABB_max_x": 691.3958129882813,
-                            "worldAABB_max_y": 435.4999694824219
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -22913,10 +22893,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -22966,10 +22946,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23019,10 +22999,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 692.9729614257813,
-                            "worldAABB_min_y": 383.36456298828125,
-                            "worldAABB_max_x": 702.9989624023438,
-                            "worldAABB_max_y": 407.42706298828125
+                            "worldAABB_min_x": 758.67041015625,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 769.64697265625,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23088,10 +23068,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 611.1874389648438,
-                            "worldAABB_min_y": 355.2916564941406,
-                            "worldAABB_max_x": 691.3958129882813,
-                            "worldAABB_max_y": 435.4999694824219
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -23140,10 +23120,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23193,10 +23173,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23246,10 +23226,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 693.2708129882813,
-                            "worldAABB_min_y": 383.36456298828125,
-                            "worldAABB_max_x": 703.2968139648438,
-                            "worldAABB_max_y": 407.42706298828125
+                            "worldAABB_min_x": 758.9965209960938,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 769.9730834960938,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23315,10 +23295,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 611.1874389648438,
-                            "worldAABB_min_y": 355.2916564941406,
-                            "worldAABB_max_x": 691.3958129882813,
-                            "worldAABB_max_y": 435.4999694824219
+                            "worldAABB_min_x": 669.1312255859375,
+                            "worldAABB_min_y": 430.9375,
+                            "worldAABB_max_x": 756.9437255859375,
+                            "worldAABB_max_y": 518.75
                         }
                     },
                     {
@@ -23367,10 +23347,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23420,10 +23400,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 603.9686889648438,
-                            "worldAABB_min_y": 348.0729064941406,
-                            "worldAABB_max_x": 698.6145629882813,
-                            "worldAABB_max_y": 442.7187194824219
+                            "worldAABB_min_x": 661.2280883789063,
+                            "worldAABB_min_y": 423.03436279296875,
+                            "worldAABB_max_x": 764.8468627929688,
+                            "worldAABB_max_y": 526.6531372070313
                         }
                     },
                     {
@@ -23473,10 +23453,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 724.610595703125,
-                            "worldAABB_min_y": 383.36456298828125,
-                            "worldAABB_max_x": 734.6365966796875,
-                            "worldAABB_max_y": 407.42706298828125
+                            "worldAABB_min_x": 793.3074340820313,
+                            "worldAABB_min_y": 461.671875,
+                            "worldAABB_max_x": 804.2839965820313,
+                            "worldAABB_max_y": 488.015625
                         }
                     },
                     {
@@ -23508,6 +23488,88 @@
                             "colorClicked_z": 0.5,
                             "colorClicked_w": 1.0,
                             "sceneName": ""
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "EnemyDetection",
+                "tag": "",
+                "uid": 12448675388407140002,
+                "parentUID": 1326767777895378518,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 0.0,
+                            "localPos_Z": 0.0,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 1.0,
+                            "localSca_Y": 1.0,
+                            "localSca_Z": 1.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_RigidBody",
+                            "active": true,
+                            "removed": true,
+                            "isKinematic": false,
+                            "isTrigger": true,
+                            "drawCollider": true,
+                            "mass": 1.0,
+                            "linearDamping": 0.10000000149011612,
+                            "angularDamping": 0.10000000149011612,
+                            "restitution": 0.0,
+                            "currentShape": 2,
+                            "usePositionController": false,
+                            "useRotationController": false,
+                            "KpForce": 5.0,
+                            "KpTorque": 0.05000000074505806,
+                            "gravity_Y": 1.0,
+                            "boxSize_X": 0.0,
+                            "boxSize_Y": 0.0,
+                            "boxSize_Z": 0.0,
+                            "radius": 6.5,
+                            "factor": 0.5,
+                            "height": 2.0,
+                            "rbPos_X": 0.0,
+                            "rbPos_Y": 0.0,
+                            "rbPos_Z": -14.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Script",
+                            "active": true,
+                            "removed": true,
+                            "constructName": "EntityDetection",
+                            "fields": [
+                                {
+                                    "name": "Player",
+                                    "value": 1326767777895378518,
+                                    "type": 2
+                                },
+                                {
+                                    "name": "InteractionAngle",
+                                    "value": 50.0,
+                                    "type": 0
+                                },
+                                {
+                                    "name": "InteractionOffset",
+                                    "value": 1.0,
+                                    "type": 0
+                                }
+                            ]
                         }
                     }
                 ]

--- a/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
@@ -6743,33 +6743,13 @@
                                     "type": 0
                                 },
                                 {
-                                    "name": "RayAttackSize",
-                                    "value": 10.0,
-                                    "type": 0
-                                },
-                                {
                                     "name": "AnimationGO",
-                                    "value": 0,
+                                    "value": 1326767777895378518,
                                     "type": 2
                                 },
                                 {
-                                    "name": "Ray1GO",
-                                    "value": 0,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray2GO",
-                                    "value": 0,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray3GO",
-                                    "value": 0,
-                                    "type": 2
-                                },
-                                {
-                                    "name": "Ray4GO",
-                                    "value": 0,
+                                    "name": "EnemyDetectionObject",
+                                    "value": 8746673805549693416,
                                     "type": 2
                                 }
                             ]
@@ -23568,6 +23548,11 @@
                                 {
                                     "name": "InteractionAngle",
                                     "value": 50.0,
+                                    "type": 0
+                                },
+                                {
+                                    "name": "InteractionOffset",
+                                    "value": 1.0,
                                     "type": 0
                                 }
                             ]

--- a/Game/Scripts/BixAttackScript.cpp
+++ b/Game/Scripts/BixAttackScript.cpp
@@ -65,14 +65,6 @@ void BixAttackScript::Update(float deltaTime)
 	// This should go inside the PerformAttack() function but delay setting it to false by 2 seconds or smth like that
 	animation->SetParameter("IsAttacking", false);
 
-
-#ifdef DEBUG
-	for (const Ray& ray : rays)
-	{
-		dd::arrow(ray.pos, ray.pos + ray.dir * rayAttackSize, dd::colors::Red, 0.05f);
-	}
-#endif // DEBUG
-
 	CheckCombo();
 }
 

--- a/Game/Scripts/BixAttackScript.h
+++ b/Game/Scripts/BixAttackScript.h
@@ -10,6 +10,7 @@ class ModuleInput;
 class ComponentAudioSource;
 class ComponentTransform;
 class ComponentAnimation;
+class EntityDetection;
 
 class PlayerManagerScript;
 
@@ -51,24 +52,10 @@ private:
 	ComponentTransform* transform;
 	ComponentAnimation* animation;
 	GameObject* animationGO;
+	EntityDetection* enemyDetection;
+	GameObject* enemyDetectionObject;
 
 	ModuleInput* input;
-
-	//Provisional
-	std::vector<Ray> rays;
-
-	GameObject* ray1GO;
-	GameObject* ray2GO;
-	GameObject* ray3GO;
-	GameObject* ray4GO;
-
-	ComponentTransform* ray1Transform;
-	ComponentTransform* ray2Transform;
-	ComponentTransform* ray3Transform;
-	ComponentTransform* ray4Transform;
-
-	float rayAttackSize;
-	//--Provisional
 
 	PlayerManagerScript* playerManager;
 	AttackCombo attackComboPhase;

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -1,0 +1,105 @@
+#include "StdAfx.h"
+#include "EntityDetection.h"
+
+#include "Application.h"
+
+#include "ModuleInput.h"
+
+#include "Components/ComponentRigidBody.h"
+#include "Components/ComponentTransform.h"
+#include "GameObject/GameObject.h"
+
+#include "debugdraw.h"
+
+#include <set>
+
+#include "AxoLog.h"
+
+REGISTERCLASS(EntityDetection);
+
+EntityDetection::EntityDetection() : Script(), input(nullptr), rigidBody(nullptr), player(nullptr), 
+interactionAngle(30.0f), playerTransform(nullptr)
+{
+	REGISTER_FIELD(player, GameObject*);
+	REGISTER_FIELD(interactionAngle, float);
+}
+
+void EntityDetection::Start()
+{
+	rigidBody = owner->GetComponent<ComponentRigidBody>();
+	playerTransform = player->GetComponent<ComponentTransform>();
+
+	input = App->GetModule<ModuleInput>();
+
+	rigidBody->SetKpForce(50);
+}
+
+void EntityDetection::Update(float deltaTime)
+{
+	rigidBody->SetPositionTarget(playerTransform->GetGlobalPosition());
+
+
+	float3 vecForward = playerTransform->GetGlobalForward();
+
+	float newMagnitude = rigidBody->GetRadius() * rigidBody->GetFactor();
+
+	float3 vecRotated = Quat::RotateAxisAngle(float3::unitY, math::DegToRad(interactionAngle)) * vecForward;
+	dd::line(playerTransform->GetGlobalPosition(),
+		playerTransform->GetGlobalPosition() + newMagnitude * vecRotated.Normalized(),
+		dd::colors::BlueViolet);
+
+	vecRotated = Quat::RotateAxisAngle(float3::unitY, math::DegToRad(-interactionAngle)) * vecForward;
+	dd::line(playerTransform->GetGlobalPosition(),
+		playerTransform->GetGlobalPosition() + newMagnitude * vecRotated.Normalized(),
+		dd::colors::BlueViolet);
+
+
+	dd::line(playerTransform->GetGlobalPosition(), playerTransform->GetGlobalPosition() +
+		playerTransform->GetGlobalForward().Normalized() * rigidBody->GetRadius() * rigidBody->GetFactor(),
+		dd::colors::IndianRed);
+
+
+	
+	for (GameObject* enemy : enemiesInTheArea) 
+	{
+		float3 vecTowardsEnemy = enemy->GetComponent<ComponentTransform>()->GetGlobalPosition() - playerTransform->GetGlobalPosition();
+	
+		vecForward = vecForward.Normalized();
+		vecTowardsEnemy = vecTowardsEnemy.Normalized();
+
+		float angle = Quat::FromEulerXYZ(vecForward.x, vecForward.y, vecForward.z).
+			AngleBetween(Quat::FromEulerXYZ(vecTowardsEnemy.x, vecTowardsEnemy.y, vecTowardsEnemy.z));
+
+		
+		float3 color = dd::colors::Blue;
+		float finalAngle = math::Abs(math::RadToDeg(angle));
+		if (finalAngle < interactionAngle)
+		{
+			color = dd::colors::Red;
+		}
+
+		dd::sphere(enemy->GetComponent<ComponentTransform>()->GetGlobalPosition(),
+			color, 1.0f);
+	}
+
+}
+
+void EntityDetection::OnCollisionEnter(ComponentRigidBody* other)
+{
+	if (other->GetOwner()->GetTag() == "Enemy")
+	{
+		enemiesInTheArea.push_back(other->GetOwner());
+	}
+}
+
+void EntityDetection::OnCollisionExit(ComponentRigidBody* other)
+{
+	enemiesInTheArea.erase(
+		std::remove_if(
+			std::begin(enemiesInTheArea), std::end(enemiesInTheArea), [other](const GameObject* gameObject)
+			{
+				return gameObject == other->GetOwner();
+			}
+		),
+		std::end(enemiesInTheArea));
+}

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -115,8 +115,10 @@ void EntityDetection::SelectEnemy()
 #ifdef ENGINE
 		//Draw enemies inside the sphere
 		dd::sphere(enemy->GetGlobalPosition(), color, 0.5f);
+#endif // ENGINE
 	}
 
+#ifdef ENGINE
 	if (enemySelected != nullptr)
 	{
 		//Draw arrow to the enemy selected

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -9,6 +9,8 @@
 #include "Components/ComponentTransform.h"
 #include "GameObject/GameObject.h"
 
+#include "../Scripts/HealthSystem.h"
+
 #include "debugdraw.h"
 
 #include <set>
@@ -58,6 +60,9 @@ void EntityDetection::Update(float deltaTime)
 
 	for (ComponentTransform* enemy : enemiesInTheArea)
 	{
+		if (!enemy->GetOwner()->GetComponent<HealthSystem>()->EntityIsAlive())
+			continue;
+
 		vecForward = vecForward.Normalized();
 		float3 vecTowardsEnemy = (enemy->GetGlobalPosition() - originPosition).Normalized();
 

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -46,6 +46,11 @@ void EntityDetection::Update(float deltaTime)
 	vecForward = playerTransform->GetGlobalForward();
 	originPosition = playerTransform->GetGlobalPosition() - vecForward.Normalized() * interactionOffset;
 
+	if (interactionOffset > 0.0f)
+	{
+		interactionOffset = 0.0f;
+	}
+
 	DrawDetectionLines();
 	
 	SelectEnemy();

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -51,7 +51,9 @@ void EntityDetection::Update(float deltaTime)
 		interactionOffset = 0.0f;
 	}
 
+#ifdef ENGINE
 	DrawDetectionLines();
+#endif // ENGINE
 	
 	SelectEnemy();
 }
@@ -85,14 +87,18 @@ void EntityDetection::SelectEnemy()
 		float angle = Quat::FromEulerXYZ(vecForward.x, vecForward.y, vecForward.z).
 			AngleBetween(Quat::FromEulerXYZ(vecTowardsEnemy.x, vecTowardsEnemy.y, vecTowardsEnemy.z));
 
+#ifdef ENGINE
 		float3 color = dd::colors::Blue;
+#endif // ENGINE
 
 		float dotProduct = vecTowardsEnemy.Dot((playerTransform->GetGlobalPosition() - originPosition).Normalized());
 		angle = math::Abs(math::RadToDeg(angle));
 
 		if (angle < interactionAngle && dotProduct > 0) //Enemy is inside angle and in front of player
 		{
+#ifdef ENGINE
 			color = dd::colors::Red;
+#endif // ENGINE
 
 			if (enemySelected == nullptr)
 			{
@@ -106,6 +112,7 @@ void EntityDetection::SelectEnemy()
 			}
 		}
 
+#ifdef ENGINE
 		//Draw enemies inside the sphere
 		dd::sphere(enemy->GetGlobalPosition(), color, 0.5f);
 	}
@@ -115,6 +122,7 @@ void EntityDetection::SelectEnemy()
 		//Draw arrow to the enemy selected
 		dd::arrow(originPosition, enemySelected->GetGlobalPosition(), dd::colors::Red, 0.1f);
 	}
+#endif // ENGINE
 }
 
 void EntityDetection::OnCollisionEnter(ComponentRigidBody* other)

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -18,7 +18,7 @@
 REGISTERCLASS(EntityDetection);
 
 EntityDetection::EntityDetection() : Script(), input(nullptr), rigidBody(nullptr), player(nullptr), 
-interactionAngle(30.0f), playerTransform(nullptr)
+interactionAngle(50.0f), playerTransform(nullptr)
 {
 	REGISTER_FIELD(player, GameObject*);
 	REGISTER_FIELD(interactionAngle, float);
@@ -76,10 +76,13 @@ void EntityDetection::Update(float deltaTime)
 		if (finalAngle < interactionAngle)
 		{
 			color = dd::colors::Red;
+
+			dd::arrow(playerTransform->GetGlobalPosition(), enemy->GetComponent<ComponentTransform>()->GetGlobalPosition(),
+				dd::colors::Red, 0.5f);
 		}
 
 		dd::sphere(enemy->GetComponent<ComponentTransform>()->GetGlobalPosition(),
-			color, 1.0f);
+			color, 0.5f);
 	}
 
 }

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -18,7 +18,7 @@
 REGISTERCLASS(EntityDetection);
 
 EntityDetection::EntityDetection() : Script(), input(nullptr), rigidBody(nullptr), player(nullptr), 
-interactionAngle(50.0f), playerTransform(nullptr)
+interactionAngle(50.0f), playerTransform(nullptr), enemySelected(nullptr)
 {
 	REGISTER_FIELD(player, GameObject*);
 	REGISTER_FIELD(interactionAngle, float);
@@ -58,7 +58,7 @@ void EntityDetection::Update(float deltaTime)
 		playerTransform->GetGlobalForward().Normalized() * rigidBody->GetRadius() * rigidBody->GetFactor(),
 		dd::colors::IndianRed);
 
-
+	enemySelected = nullptr;
 	
 	for (GameObject* enemy : enemiesInTheArea) 
 	{
@@ -77,12 +77,30 @@ void EntityDetection::Update(float deltaTime)
 		{
 			color = dd::colors::Red;
 
-			dd::arrow(playerTransform->GetGlobalPosition(), enemy->GetComponent<ComponentTransform>()->GetGlobalPosition(),
-				dd::colors::Red, 0.5f);
+			if (enemySelected == nullptr)
+			{
+				enemySelected = enemy;
+			}
+			else
+			{
+				float3 currentEnemyPosition = enemy->GetComponent<ComponentTransform>()->GetGlobalPosition();
+				float3 lastEnemyPosition = enemySelected->GetComponent<ComponentTransform>()->GetGlobalPosition();
+				if (playerTransform->GetGlobalPosition().Distance(currentEnemyPosition) < playerTransform->GetGlobalPosition().Distance(lastEnemyPosition))
+				{
+					enemySelected = enemy;
+				}
+			}
+
 		}
 
 		dd::sphere(enemy->GetComponent<ComponentTransform>()->GetGlobalPosition(),
 			color, 0.5f);
+	}
+
+	if (enemySelected != nullptr)
+	{
+		dd::arrow(playerTransform->GetGlobalPosition(), enemySelected->GetComponent<ComponentTransform>()->GetGlobalPosition(),
+			dd::colors::Red, 0.5f);
 	}
 
 }

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -107,6 +107,11 @@ void EntityDetection::OnCollisionEnter(ComponentRigidBody* other)
 
 void EntityDetection::OnCollisionExit(ComponentRigidBody* other)
 {
+	if (enemySelected == other->GetOwner()->GetComponent<ComponentTransform>())
+	{
+		enemySelected = nullptr;
+	}
+
 	enemiesInTheArea.erase(
 		std::remove_if(
 			std::begin(enemiesInTheArea), std::end(enemiesInTheArea), [other](const ComponentTransform* transform)
@@ -115,4 +120,18 @@ void EntityDetection::OnCollisionExit(ComponentRigidBody* other)
 			}
 		),
 		std::end(enemiesInTheArea));
+}
+
+
+
+GameObject* EntityDetection::GetEnemySelected() const
+{
+	if (enemySelected != nullptr)
+	{
+		return enemySelected->GetOwner();
+	}
+	else
+	{
+		return nullptr;
+	}
 }

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -75,7 +75,10 @@ void EntityDetection::Update(float deltaTime)
 		
 		float3 color = dd::colors::Blue;
 		float finalAngle = math::Abs(math::RadToDeg(angle));
-		if (finalAngle < interactionAngle)
+
+		float dotProduct = vecTowardsEnemy.Dot((playerTransform->GetGlobalPosition() - originPosition).Normalized());
+
+		if (finalAngle < interactionAngle && dotProduct > 0)
 		{
 			color = dd::colors::Red;
 

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -31,6 +31,7 @@ private:
 	ComponentRigidBody* rigidBody;
 
 	float interactionAngle;
+	float interactionOffset;
 
 	std::vector<GameObject*> enemiesInTheArea;
 	GameObject* enemySelected;

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -33,6 +33,6 @@ private:
 	float interactionAngle;
 	float interactionOffset;
 
-	std::vector<GameObject*> enemiesInTheArea;
-	GameObject* enemySelected;
+	std::vector<ComponentTransform*> enemiesInTheArea;
+	ComponentTransform* enemySelected;
 };

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -20,6 +20,8 @@ public:
 	virtual void OnCollisionEnter(ComponentRigidBody* other) override;
 	virtual void OnCollisionExit(ComponentRigidBody* other) override;
 
+	GameObject* GetEnemySelected() const;
+
 private:
 	void Start() override;
 	void Update(float deltaTime) override;
@@ -36,3 +38,15 @@ private:
 	std::vector<ComponentTransform*> enemiesInTheArea;
 	ComponentTransform* enemySelected;
 };
+
+inline GameObject* EntityDetection::GetEnemySelected() const
+{
+	if (enemySelected != nullptr)
+	{
+		return enemySelected->GetOwner();
+	}
+	else
+	{
+		return nullptr;
+	}
+}

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -26,6 +26,9 @@ private:
 	void Start() override;
 	void Update(float deltaTime) override;
 
+	void DrawDetectionLines();
+	void SelectEnemy();
+
 	ModuleInput* input;
 
 	GameObject* player;
@@ -37,4 +40,7 @@ private:
 
 	std::vector<ComponentTransform*> enemiesInTheArea;
 	ComponentTransform* enemySelected;
+
+	float3 vecForward;
+	float3 originPosition;
 };

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Scripting\Script.h"
+#include "RuntimeInclude.h"
+
+RUNTIME_MODIFIABLE_INCLUDE;
+
+class ModuleInput;
+class ComponentRigidBody;
+class ComponentTransform;
+class GameObject;
+
+class EntityDetection : public Script
+{
+
+public:
+	EntityDetection();
+	~EntityDetection() override = default;
+
+	virtual void OnCollisionEnter(ComponentRigidBody* other) override;
+	virtual void OnCollisionExit(ComponentRigidBody* other) override;
+
+private:
+	void Start() override;
+	void Update(float deltaTime) override;
+
+	ModuleInput* input;
+
+	GameObject* player;
+	ComponentTransform* playerTransform;
+	ComponentRigidBody* rigidBody;
+
+	float interactionAngle;
+
+	std::vector<GameObject*> enemiesInTheArea;
+};

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -38,15 +38,3 @@ private:
 	std::vector<ComponentTransform*> enemiesInTheArea;
 	ComponentTransform* enemySelected;
 };
-
-inline GameObject* EntityDetection::GetEnemySelected() const
-{
-	if (enemySelected != nullptr)
-	{
-		return enemySelected->GetOwner();
-	}
-	else
-	{
-		return nullptr;
-	}
-}

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -33,4 +33,5 @@ private:
 	float interactionAngle;
 
 	std::vector<GameObject*> enemiesInTheArea;
+	GameObject* enemySelected;
 };

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -173,6 +173,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\Game\Scripts\AnimatedTexture.cpp" />
+    <ClCompile Include="..\Game\Scripts\EntityDetection.cpp" />
     <ClCompile Include="..\Game\Scripts\MeleeHeavyAttackBehaviourScript.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseEngine|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseGame|x64'">NotUsing</PrecompiledHeader>
@@ -743,6 +744,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\Game\Scripts\AnimatedTexture.h" />
+    <ClInclude Include="..\Game\Scripts\EntityDetection.h" />
     <ClInclude Include="..\Game\Scripts\MeleeHeavyAttackBehaviourScript.h" />
     <ClInclude Include="..\Game\Scripts\ActivationLogic.h" />
     <ClInclude Include="..\Game\Scripts\EnemyDeathScript.h" />

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -603,6 +603,9 @@
     <ClCompile Include="..\Game\Scripts\AnimatedTexture.cpp">
       <Filter>UserScripts\Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="..\Game\Scripts\EntityDetection.cpp">
+      <Filter>UserScripts\Gameplay\Player\Attack</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DataModels\Timer\Timer.h">
@@ -1241,6 +1244,9 @@
     <ClInclude Include="..\Game\Scripts\DefaultScript.h" />
     <ClInclude Include="..\Game\Scripts\AnimatedTexture.h">
       <Filter>UserScripts\Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Game\Scripts\EntityDetection.h">
+      <Filter>UserScripts\Gameplay\Player\Attack</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Entity detection is in charge of detecting which enemy is in front of the player in order to perform attacks to them.
It consists on a sphere detecting all enemies near the player and an angle detecting which of them are in front of the player. The enemy selected will be, for the moment, the nearest to the player inside this angle. For now, the player only hits one enemy at the time.
I've also linked this script with the BixAttack script in order to hit the enemy selected.

To test this you can go to the GameplayFullTrial_VS3.axolotl