### PR TITLE
feat: Combat camera

### DIFF
--- a/Game/Scripts/CameraControllerScript.cpp
+++ b/Game/Scripts/CameraControllerScript.cpp
@@ -134,16 +134,33 @@ void CameraControllerScript::CalculateFocusOffsetVector(float2 offset)
 ComponentCameraSample* CameraControllerScript::FindClosestSample(float3 position)
 {
 	ComponentCameraSample* closestSample = nullptr;
-	float minDistance = std::numeric_limits<float>::max();
+	ComponentCameraSample* closestCombatSample = nullptr;
 
-	for (auto sample : samples)
+	float minDistance = std::numeric_limits<float>::max();
+	float minCombatDistance = std::numeric_limits<float>::max();
+
+	for (ComponentCameraSample* sample : samples)
 	{
 		float distance = (sample->GetPosition() - position).Length();
-		if (distance < minDistance && distance <= sample->GetRadius())
+
+		if (distance <= sample->GetRadius())
 		{
-			closestSample = sample;
-			minDistance = distance;
+			if (sample->GetCombatCameraEnabled() && distance < minCombatDistance)
+			{
+				closestCombatSample = sample;
+				minCombatDistance = distance;
+			}
+			else if (distance < minDistance)
+			{
+				closestSample = sample;
+				minDistance = distance;
+			}
 		}
 	}
-	return closestSample;
+
+	if (closestCombatSample)
+		return closestCombatSample;
+	else
+		return closestSample;
 }
+

--- a/Source/DataModels/Components/ComponentCameraSample.cpp
+++ b/Source/DataModels/Components/ComponentCameraSample.cpp
@@ -45,7 +45,8 @@ void ComponentCameraSample::Draw() const
 {
 #ifdef ENGINE
 	bool canDrawSample = 
-		IsEnabled() && GetOwner() == App->GetModule<ModuleScene>()->GetSelectedGameObject();
+		(IsEnabled() && GetOwner() == App->GetModule<ModuleScene>()->GetSelectedGameObject()) 
+		|| GetOwner()->GetParent() == App->GetModule<ModuleScene>()->GetSelectedGameObject();
 
 	if (!canDrawSample)
 	{

--- a/Source/DataModels/Components/ComponentCameraSample.cpp
+++ b/Source/DataModels/Components/ComponentCameraSample.cpp
@@ -22,6 +22,7 @@ ComponentCameraSample::ComponentCameraSample(const bool active, GameObject* owne
 	position = GetOwner()->GetComponent<ComponentTransform>()->GetGlobalPosition();
 	isSampleFocusEnabled = false;
 	isSampleFixedEnabled = false;
+	isCombatCameraEnabled = false;
 }
 
 ComponentCameraSample::ComponentCameraSample(const ComponentCameraSample& componentCameraSample):
@@ -30,7 +31,8 @@ ComponentCameraSample::ComponentCameraSample(const ComponentCameraSample& compon
 	positionOffset(componentCameraSample.positionOffset),
 	position(componentCameraSample.position),
 	isSampleFocusEnabled(componentCameraSample.isSampleFocusEnabled),
-	isSampleFixedEnabled(componentCameraSample.isSampleFixedEnabled)
+	isSampleFixedEnabled(componentCameraSample.isSampleFixedEnabled),
+	isCombatCameraEnabled(componentCameraSample.isCombatCameraEnabled)
 {
 }
 
@@ -74,6 +76,7 @@ void ComponentCameraSample::InternalSave(Json& meta)
 
 	meta["isSampleFocusEnabled"] = (bool) isSampleFocusEnabled;
 	meta["isSampleFixedEnabled"] = (bool) isSampleFixedEnabled;
+	meta["isCombatCameraEnabled"] = (bool) isCombatCameraEnabled;
 
 	position = GetOwner()->GetComponent<ComponentTransform>()->GetGlobalPosition();
 	meta["positionX"] = (float) position.x;
@@ -99,6 +102,7 @@ void ComponentCameraSample::InternalLoad(const Json& meta)
 
 	isSampleFocusEnabled = meta["isSampleFocusEnabled"];
 	isSampleFixedEnabled = meta["isSampleFixedEnabled"];
+	isCombatCameraEnabled = meta["isCombatCameraEnabled"];
 
 	position.x = meta["positionX"];
 	position.y = meta["positionY"];

--- a/Source/DataModels/Components/ComponentCameraSample.cpp
+++ b/Source/DataModels/Components/ComponentCameraSample.cpp
@@ -55,7 +55,14 @@ void ComponentCameraSample::Draw() const
 	ComponentTransform* transform = GetOwner()->GetComponent<ComponentTransform>();
 	float3 position = transform->GetGlobalPosition();
 
-	dd::sphere(position, dd::colors::Yellow, influenceRadius);
+	if (isCombatCameraEnabled)
+	{
+		dd::sphere(position, dd::colors::Orange, influenceRadius);
+	}
+	else
+	{
+		dd::sphere(position, dd::colors::Yellow, influenceRadius);
+	}
 #endif
 }
 

--- a/Source/DataModels/Components/ComponentCameraSample.h
+++ b/Source/DataModels/Components/ComponentCameraSample.h
@@ -37,6 +37,8 @@ public:
 
 	float3 GetPosition() const;
 
+	bool GetCombatCameraEnabled() const;
+
 private:
 	
 	void InternalSave(Json& meta) override;
@@ -51,6 +53,8 @@ private:
 
 	bool isSampleFocusEnabled;
 	float2 focusOffset;
+
+	bool isCombatCameraEnabled;
 };
 
 inline float ComponentCameraSample::GetRadius() const
@@ -116,4 +120,9 @@ inline void ComponentCameraSample::SetFocusOffset(float2 offset)
 inline float3 ComponentCameraSample::GetPosition() const
 {
 	return position;
+}
+
+inline bool ComponentCameraSample::GetCombatCameraEnabled() const
+{
+	return isCombatCameraEnabled;
 }

--- a/Source/DataModels/Components/ComponentCameraSample.h
+++ b/Source/DataModels/Components/ComponentCameraSample.h
@@ -17,6 +17,9 @@ public:
 
 	void Draw() const override;
 
+	bool GetCombatCameraEnabled() const;
+	void SetCombatCameraEnabled(bool enabled);
+
 	float GetRadius() const;
 	void SetRadius(float radius);
 
@@ -37,12 +40,12 @@ public:
 
 	float3 GetPosition() const;
 
-	bool GetCombatCameraEnabled() const;
-
 private:
 	
 	void InternalSave(Json& meta) override;
 	void InternalLoad(const Json& meta) override;
+
+	bool isCombatCameraEnabled;
 
 	float3 position;
 	float influenceRadius;
@@ -54,8 +57,17 @@ private:
 	bool isSampleFocusEnabled;
 	float2 focusOffset;
 
-	bool isCombatCameraEnabled;
 };
+
+inline bool ComponentCameraSample::GetCombatCameraEnabled() const
+{
+	return isCombatCameraEnabled;
+}
+
+inline void ComponentCameraSample::SetCombatCameraEnabled(bool enabled)
+{
+	isCombatCameraEnabled = enabled;
+}
 
 inline float ComponentCameraSample::GetRadius() const
 {
@@ -120,9 +132,4 @@ inline void ComponentCameraSample::SetFocusOffset(float2 offset)
 inline float3 ComponentCameraSample::GetPosition() const
 {
 	return position;
-}
-
-inline bool ComponentCameraSample::GetCombatCameraEnabled() const
-{
-	return isCombatCameraEnabled;
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCameraSample.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCameraSample.cpp
@@ -32,6 +32,20 @@ void WindowComponentCameraSample::DrawWindowContents()
 		bool isSampleFocusEnabled = asCameraSample->GetFocusOffsetEnabled();
 		float2 focusOffset = asCameraSample->GetFocusOffset();
 
+		bool isCombatCameraEnabled = asCameraSample->GetCombatCameraEnabled();
+
+		ImGui::Text("");
+
+		if (ImGui::Checkbox("##Combat Camera Enabled", &isCombatCameraEnabled))
+		{
+			asCameraSample->SetCombatCameraEnabled(isCombatCameraEnabled);
+		}
+
+		ImGui::SameLine();
+		ImGui::Text("Combat Camera Enabled");
+
+		ImGui::Text("");
+
 		ImGui::SliderFloat("Influence Radius", &influenceRadius, 0.0f, 30.f, "%.3f", ImGuiSliderFlags_AlwaysClamp);
 
 		ImGui::Text("");


### PR DESCRIPTION
New combat sample points option:

- A Combat Point will be prioritized over general samples. The order now is the following:

1. Closest point of Combat Points
2. Combat Point with influence 
3. Closest point of General Sample Points
4. General Sample Point with influence

- Different color for distinguish both types
- For enabling Combat Point only tick the checkbox
- For QoL, if you select the parent samples object, all the children will be drawn. If not, only the ones selected will be drawn.