### PR TITLE
feat: bloom modificable for each material

### DIFF
--- a/Source/DataModels/Batch/GeometryBatch.cpp
+++ b/Source/DataModels/Batch/GeometryBatch.cpp
@@ -180,7 +180,8 @@ void GeometryBatch::FillMaterial()
 				resourceMaterial->HasEmissive(),
 				resourceMaterial->GetSmoothness(),
 				resourceMaterial->GetMetalness(),
-				resourceMaterial->GetNormalStrength()
+				resourceMaterial->GetNormalStrength(),
+				resourceMaterial->GetIntensityBloom()
 			};
 
 			std::shared_ptr<ResourceTexture> texture = resourceMaterial->GetDiffuse();
@@ -222,7 +223,8 @@ void GeometryBatch::FillMaterial()
 				resourceMaterial->HasEmissive(),
 				resourceMaterial->GetSmoothness(),
 				resourceMaterial->GetMetalness(),
-				static_cast<uint64_t>(resourceMaterial->GetNormalStrength())
+				static_cast<uint64_t>(resourceMaterial->GetNormalStrength()),
+				resourceMaterial->GetIntensityBloom()
 			};
 
 			std::shared_ptr<ResourceTexture> texture = resourceMaterial->GetDiffuse();

--- a/Source/DataModels/Batch/GeometryBatch.h
+++ b/Source/DataModels/Batch/GeometryBatch.h
@@ -54,35 +54,36 @@ private:
 
 	struct MaterialMetallic 
 	{
-		float4 diffuse_color = float4::zero; //0 //16
-		int has_diffuse_map = 0;			 //16 //4      
-		int has_normal_map = 0;				 //20 //4
-		int has_metallic_map = 0;			 //24 //4
-		int has_emissive_map = 0;			 //28 //4
-		float smoothness = 0;				 //32 //4
-		float metalness = 0;				 //36 //4
-		float normal_strength = 0;			 //40 //4
-		uint64_t diffuse_map;				 //48 //8
-		uint64_t normal_map;				 //56 //8
-		uint64_t metallic_map;				 //64 //8 
-		uint64_t emissive_map;				 //72 //8 -->80
+		float4 diffuse_color = float4::zero;	//0 //16
+		int has_diffuse_map = 0;				//16 //4
+		int has_normal_map = 0;					//20 //4
+		int has_metallic_map = 0;				//24 //4
+		int has_emissive_map = 0;				//28 //4
+		float smoothness = 0;					//32 //4
+		float metalness = 0;					//36 //4
+		float normal_strength = 0;				//40 //4
+		float intensityBloom = 0;				//44 //4
+		uint64_t diffuse_map;					//48 //8
+		uint64_t normal_map;					//56 //8
+		uint64_t metallic_map;					//64 //8
+		uint64_t emissive_map;					//72 //8 -->80
 	};
 
 	struct MaterialSpecular 
 	{
-		float4 diffuse_color = float4::zero;  //0  //16
-		float3 specular_color = float3::zero; //16 //16       
-		int has_diffuse_map = 0;              //32 //4
-		int has_normal_map = 0;               //36 //4
-		int has_specular_map = 0;             //40 //4
-		int has_emissive_map = 0;             //44 //4
-		float smoothness = 0;                 //48 //4
-		float normal_strength = 0;            //52 //4
-		uint64_t diffuse_map;				  //56 //8
-		uint64_t normal_map;				  //64 //8
-		uint64_t specular_map;				  //72 //8    
-		uint64_t emissive_map;				  //80 //8    
-		int padding1 = 0, padding2 = 0;		  //88 //8 --> 96
+		float4 diffuse_color = float4::zero;	//0  //16
+		float3 specular_color = float3::zero;	//16 //16
+		int has_diffuse_map = 0;				//32 //4
+		int has_normal_map = 0;					//36 //4
+		int has_specular_map = 0;				//40 //4
+		int has_emissive_map = 0;				//44 //4
+		float smoothness = 0;					//48 //4
+		float normal_strength = 0;				//52 //4
+		float intensityBloom = 0;				//56 //4
+		uint64_t diffuse_map;					//64 //8
+		uint64_t normal_map;					//72 //8
+		uint64_t specular_map;					//80 //8
+		uint64_t emissive_map;					//88 //8 --> 96
 	};
 
 	struct ResourceInfo

--- a/Source/DataModels/Resources/ResourceMaterial.cpp
+++ b/Source/DataModels/Resources/ResourceMaterial.cpp
@@ -36,6 +36,7 @@ void ResourceMaterial::CopyValues(const ResourceMaterial& rhs)
 	this->SetSpecular(rhs.GetSpecular());
 	this->SetMetallic(rhs.GetMetallic());
 	this->SetEmission(rhs.GetEmission());
+	this->SetIntensityBloom(rhs.GetIntensityBloom());
 }
 
 void ResourceMaterial::SaveLoadOptions(Json& meta)
@@ -58,6 +59,7 @@ void ResourceMaterial::SaveLoadOptions(Json& meta)
 	meta["tilingy"] = static_cast<float>(loadOptions.tiling.y);
 	meta["offsetx"] = static_cast<float>(loadOptions.offset.x);
 	meta["offsety"] = static_cast<float>(loadOptions.offset.y);
+	meta["intensityBloom"] = static_cast<float>(loadOptions.intensityBloom);
 }
 
 void ResourceMaterial::LoadLoadOptions(Json& meta)
@@ -90,6 +92,7 @@ void ResourceMaterial::LoadLoadOptions(Json& meta)
 	}
 	loadOptions.offset.x = static_cast<float>(meta["offsetx"]);
 	loadOptions.offset.y = static_cast<float>(meta["offsety"]);
+	loadOptions.intensityBloom = static_cast<float>(meta["intensityBloom"]);
 }
 
 void ResourceMaterial::SavePaths(Json& meta, const std::vector<std::string>& pathTextures)

--- a/Source/DataModels/Resources/ResourceMaterial.cpp
+++ b/Source/DataModels/Resources/ResourceMaterial.cpp
@@ -93,6 +93,10 @@ void ResourceMaterial::LoadLoadOptions(Json& meta)
 	loadOptions.offset.x = static_cast<float>(meta["offsetx"]);
 	loadOptions.offset.y = static_cast<float>(meta["offsety"]);
 	loadOptions.intensityBloom = static_cast<float>(meta["intensityBloom"]);
+	if (loadOptions.intensityBloom == 0.f)
+	{
+		loadOptions.intensityBloom = 1.f;
+	}
 }
 
 void ResourceMaterial::SavePaths(Json& meta, const std::vector<std::string>& pathTextures)

--- a/Source/DataModels/Resources/ResourceMaterial.h
+++ b/Source/DataModels/Resources/ResourceMaterial.h
@@ -13,6 +13,7 @@ struct LoadOptionsMaterial
 	bool isTransparent;
 	float2 tiling;
 	float2 offset;
+	float intensityBloom;
 
 	unsigned int shaderType; //This is a special option because it's both load and import option
 
@@ -25,7 +26,8 @@ struct LoadOptionsMaterial
 		isTransparent(false),
 		tiling(float2(1.0f)),
 		offset(float2(0.0f)),
-		shaderType(0)
+		shaderType(0),
+		intensityBloom(1.f)
 	{
 	}
 };
@@ -94,6 +96,9 @@ public:
 	void SetShaderType(const unsigned int shaderType);
 	void SetTiling(const float2& tiling);
 	void SetOffset(const float2& offset);
+	
+	const float& GetIntensityBloom() const;
+	void SetIntensityBloom(const float intensityBloom);
 
 protected:
 	void InternalLoad() override{};
@@ -265,52 +270,62 @@ inline void ResourceMaterial::SetEmission(const std::shared_ptr<ResourceTexture>
 
 inline void ResourceMaterial::SetDiffuseColor(const float4& diffuseColor)
 {
-	this->loadOptions.diffuseColor = diffuseColor;
+	loadOptions.diffuseColor = diffuseColor;
 }
 
 inline void ResourceMaterial::SetSpecularColor(const float3& specularColor)
 {
-	this->loadOptions.specularColor = specularColor;
+	loadOptions.specularColor = specularColor;
 }
 
 inline void ResourceMaterial::SetNormalStrength(const float normalStrength)
 {
-	this->loadOptions.normalStrength = normalStrength;
+	loadOptions.normalStrength = normalStrength;
 }
 
 inline void ResourceMaterial::SetSmoothness(const float smoothness)
 {
-	this->loadOptions.smoothness = smoothness;
+	loadOptions.smoothness = smoothness;
 }
 
 inline void ResourceMaterial::SetMetalness(const float metalness)
 {
-	this->loadOptions.metalness = metalness;
+	loadOptions.metalness = metalness;
 }
 
 inline void ResourceMaterial::SetTransparent(const bool isTransparent)
 {
-	this->loadOptions.isTransparent = isTransparent;
+	loadOptions.isTransparent = isTransparent;
 }
 
 inline void ResourceMaterial::SetShaderType(const unsigned int shaderType)
 {
 	if (shaderType > 1)
 	{
-		this->loadOptions.shaderType = 0;
+		loadOptions.shaderType = 0;
 	}
 	else
 	{
-		this->loadOptions.shaderType = shaderType;
+		loadOptions.shaderType = shaderType;
 	}
 }
 
 inline void ResourceMaterial::SetTiling(const float2& tiling)
 {
-	this->loadOptions.tiling = tiling;
+	loadOptions.tiling = tiling;
 }
 
 inline void ResourceMaterial::SetOffset(const float2& offset)
 {
-	this->loadOptions.offset = offset;
+	loadOptions.offset = offset;
+}
+
+inline const float& ResourceMaterial::GetIntensityBloom() const
+{
+	return loadOptions.intensityBloom;
+}
+
+inline void ResourceMaterial::SetIntensityBloom(const float intensityBloom)
+{
+	loadOptions.intensityBloom = intensityBloom;
 }

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -315,7 +315,7 @@ void Scene::RemoveEndOfLine(const GameObject* gameObject)
 						 std::views::transform(
 							 [](GameObject* gameObject)
 							 {
-								 return gameObject->GetComponent<ComponentLine>();
+								 return gameObject->GetComponentInternal<ComponentLine>();
 							 }) |
 						 std::views::filter(
 							 [gameObject](ComponentLine* component)

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -418,8 +418,8 @@ void WindowComponentMeshRenderer::DrawSetMaterial()
 				float intensityBloom = materialResource->GetIntensityBloom();
 				ImGui::Text("Bloom Intensity");
 				ImGui::SameLine();
-				ImGui::SetNextItemWidth(80.0f);
-				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.05f, 1.f))
+				ImGui::SetNextItemWidth(60.0f);
+				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.05f, 1.f, "%.2f"))
 				{
 					if (intensityBloom > 1.f)
 					{

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -415,6 +415,24 @@ void WindowComponentMeshRenderer::DrawSetMaterial()
 				ImGui::Image((void*) (intptr_t) materialResource->GetEmission()->GetGlTexture(),
 					ImVec2(100, 100));
 
+				float intensityBloom = materialResource->GetIntensityBloom();
+				ImGui::Text("Bloom Intensity");
+				ImGui::SameLine();
+				ImGui::SetNextItemWidth(80.0f);
+				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.f, 1.f))
+				{
+					if (intensityBloom > 1.f)
+					{
+						intensityBloom = 1.f;
+					}
+					else if (intensityBloom < 0.f)
+					{
+						intensityBloom = 0.f;
+					}
+					materialResource->SetIntensityBloom(intensityBloom);
+					updateMaterials = true;
+				}
+
 				if (ImGui::Button("Remove Texture Emission"))
 				{
 					materialResource->GetEmission()->Unload();

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -419,15 +419,15 @@ void WindowComponentMeshRenderer::DrawSetMaterial()
 				ImGui::Text("Bloom Intensity");
 				ImGui::SameLine();
 				ImGui::SetNextItemWidth(80.0f);
-				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.f, 1.f))
+				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.05f, 1.f))
 				{
 					if (intensityBloom > 1.f)
 					{
 						intensityBloom = 1.f;
 					}
-					else if (intensityBloom < 0.f)
+					else if (intensityBloom < 0.05f)
 					{
-						intensityBloom = 0.f;
+						intensityBloom = 0.05f;
 					}
 					materialResource->SetIntensityBloom(intensityBloom);
 					updateMaterials = true;

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -20,6 +20,9 @@
 #include "DataModels/Resources/ResourceMesh.h"
 #include "DataModels/Resources/ResourceTexture.h"
 
+#define BLOOM_MAX_VALUE 5.f
+#define BLOOM_MIN_VALUE 0.05f
+
 const std::vector<std::string> WindowComponentMeshRenderer::shaderTypes = { "Default", "Specular" };
 const std::vector<std::string> WindowComponentMeshRenderer::renderModes = { "Opaque", "Transparent" };
 
@@ -419,15 +422,15 @@ void WindowComponentMeshRenderer::DrawSetMaterial()
 				ImGui::Text("Bloom Intensity");
 				ImGui::SameLine();
 				ImGui::SetNextItemWidth(60.0f);
-				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, 0.05f, 1.f, "%.2f"))
+				if (ImGui::DragFloat("##IntensityBloom", &intensityBloom, 0.05f, BLOOM_MIN_VALUE, BLOOM_MAX_VALUE, "%.2f"))
 				{
-					if (intensityBloom > 1.f)
+					if (intensityBloom > BLOOM_MAX_VALUE)
 					{
-						intensityBloom = 1.f;
+						intensityBloom = BLOOM_MAX_VALUE;
 					}
-					else if (intensityBloom < 0.05f)
+					else if (intensityBloom < BLOOM_MIN_VALUE)
 					{
-						intensityBloom = 0.05f;
+						intensityBloom = BLOOM_MIN_VALUE;
 					}
 					materialResource->SetIntensityBloom(intensityBloom);
 					updateMaterials = true;

--- a/Source/Shaders/color_correction_fragment.glsl
+++ b/Source/Shaders/color_correction_fragment.glsl
@@ -49,7 +49,7 @@ void main()
     if (bloomActivation == 1)
     {
         vec4 bloomColor = texture(bloomBlur, TexCoord);
-        float intensity = bloomColor.a;
+        float intensity = bloomColor.a * 5;
         hdrColor += bloomColor.rgb * intensity; // additive blending
     }
     

--- a/Source/Shaders/color_correction_fragment.glsl
+++ b/Source/Shaders/color_correction_fragment.glsl
@@ -48,8 +48,9 @@ void main()
     vec3 hdrColor = texture(scene, TexCoord).rgb;      
     if (bloomActivation == 1)
     {
-        vec3 bloomColor = texture(bloomBlur, TexCoord).rgb;
-        hdrColor += bloomColor; // additive blending
+        vec4 bloomColor = texture(bloomBlur, TexCoord);
+        float intensity = bloomColor.a;
+        hdrColor += bloomColor.rgb * intensity; // additive blending
     }
     
     // tone mapping

--- a/Source/Shaders/gBuffer_Metallic_fs.glsl
+++ b/Source/Shaders/gBuffer_Metallic_fs.glsl
@@ -98,6 +98,6 @@ void main()
     gEmissive= vec4(0.0);
     if (material.has_emissive_map == 1) 
     {
-        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom);
+        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom / 5);
     }
 }

--- a/Source/Shaders/gBuffer_Metallic_fs.glsl
+++ b/Source/Shaders/gBuffer_Metallic_fs.glsl
@@ -7,16 +7,17 @@
 
 struct Material {
     vec4 diffuse_color;         //0 //16
-    int has_diffuse_map;        //16 //4       
+    int has_diffuse_map;        //16 //4
     int has_normal_map;         //20 //4
     int has_metallic_map;       //24 //4
     int has_emissive_map;       //28 //4
     float smoothness;           //32 //4
     float metalness;            //36 //4
     float normal_strength;      //40 //4
+	float intensityBloom;       //44 //4
     sampler2D diffuse_map;      //48 //8
     sampler2D normal_map;       //56 //8
-    sampler2D metallic_map;     //64 //8 
+    sampler2D metallic_map;     //64 //8
     sampler2D emissive_map;     //72 //8 -->80
 };
 
@@ -97,6 +98,6 @@ void main()
     gEmissive= vec4(0.0);
     if (material.has_emissive_map == 1) 
     {
-        gEmissive.rgb = vec3(texture(material.emissive_map, newTexCoord).rgb);
+        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom);
     }
 }

--- a/Source/Shaders/gBuffer_Specular_fs.glsl
+++ b/Source/Shaders/gBuffer_Specular_fs.glsl
@@ -14,11 +14,11 @@ struct Material {
     int has_emissive_map;       //44 //4
     float smoothness;           //48 //4
     float normal_strength;      //52 //4
-    sampler2D diffuse_map;      //56 //8
-    sampler2D normal_map;       //64 //8
-    sampler2D specular_map;     //72 //8    
-    sampler2D emissive_map;     //80 //8
-    int padding1, padding2;     //88 //8 --> 96
+	float intensityBloom;		//56 //4
+    sampler2D diffuse_map;      //64 //8
+    sampler2D normal_map;       //72 //8
+    sampler2D specular_map;     //80 //8    
+    sampler2D emissive_map;     //88 //8 --> 96
 };
 
 struct Tiling {
@@ -88,6 +88,6 @@ void main()
     gEmissive= vec4(0.0);
     if (material.has_emissive_map == 1) 
     {
-        gEmissive.rgb = vec3(texture(material.emissive_map, newTexCoord).rgb);
+        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom);
     }
 } 

--- a/Source/Shaders/gBuffer_Specular_fs.glsl
+++ b/Source/Shaders/gBuffer_Specular_fs.glsl
@@ -88,6 +88,6 @@ void main()
     gEmissive= vec4(0.0);
     if (material.has_emissive_map == 1) 
     {
-        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom);
+        gEmissive = vec4(texture(material.emissive_map, newTexCoord).rgb, material.intensityBloom / 5);
     }
 } 


### PR DESCRIPTION
As mentioned during wednesday's meeting i added a drag to manipulate the bloom intensity of each material, you can find it below the emissive texture. I have limited the value  between 0.05 and 1. For test it you can use the level 1. Remember that with F1 you can disable the bloom.