### PR TITLE
fix[WindowComponentMeshRenderer]: remove call to BeginChild

### DIFF
--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -66,15 +66,13 @@ void WindowComponentMeshRenderer::SetMaterial(const std::shared_ptr<ResourceMate
 
 void WindowComponentMeshRenderer::DrawWindowContents()
 {
-	if (changed)
-	{
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(75, 25, 25, 255));
-	}
-	else
-	{
-		ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(0, 0, 0, 0));
-	}
-	ImGui::PushID("##Window");
+	// from https://github.com/ocornut/imgui/issues/3647
+
+	ImDrawList* draw_list = ImGui::GetWindowDrawList();
+	draw_list->ChannelsSplit(2);
+	draw_list->ChannelsSetCurrent(1);
+
+	ImGui::BeginGroup();
 	DrawEnableAndDeleteComponent();
 
 	// used to ignore the ImGui::SameLine called in DrawEnableAndDeleteComponent
@@ -161,8 +159,22 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 		}
 	}
 
-	ImGui::PopID();
-	ImGui::PopStyleColor();
+	ImGui::EndGroup();
+
+	// from https://github.com/ocornut/imgui/issues/3647
+
+	if (changed)
+	{
+		draw_list->ChannelsSetCurrent(0);
+
+		ImVec2 itemRectMin = ImGui::GetItemRectMin();
+		ImVec2 itemRectMax = ImGui::GetItemRectMax();
+		itemRectMax.x = ImGui::GetContentRegionMax().x + ImGui::GetWindowPos().x;
+
+		draw_list->AddRectFilled(itemRectMin, itemRectMax, IM_COL32(75, 25, 25, 255));
+	}
+
+	draw_list->ChannelsMerge();
 }
 
 void WindowComponentMeshRenderer::DrawSetMaterial()

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -74,11 +74,11 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 	{
 		ImGui::PushStyleColor(ImGuiCol_ChildBg, IM_COL32(0, 0, 0, 0));
 	}
-	ImGui::BeginChild("##Window");
+	ImGui::PushID("##Window");
 	DrawEnableAndDeleteComponent();
 
 	// used to ignore the ImGui::SameLine called in DrawEnableAndDeleteComponent
-	ImGui::Text("");
+	ImGui::NewLine();
 
 	ComponentMeshRenderer* asMeshRenderer = static_cast<ComponentMeshRenderer*>(component);
 
@@ -161,7 +161,7 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 		}
 	}
 
-	ImGui::EndChild();
+	ImGui::PopID();
 	ImGui::PopStyleColor();
 }
 


### PR DESCRIPTION
As per `ImGui::BeginChild` documentation (skipping to the relevant part):

> For each independent axis of 'size': ==0.0f: use remaining host window size / >0.0f: fixed size / <0.0f: use remaining window size minus abs(size) / Each axis can use a different mode, e.g. ImVec2(0,400).

Looks like this was the reason the window took the remaining space of the parent window.