### PR TITLE
Feat: Attack Movement Improvement

### DIFF
--- a/Game/Scripts/BixAttackScript.cpp
+++ b/Game/Scripts/BixAttackScript.cpp
@@ -39,8 +39,7 @@ BixAttackScript::BixAttackScript() : Script(),
 	isAttacking(false), attackCooldown(0.6f), attackCooldownCounter(0.f), audioSource(nullptr),
 	animation(nullptr), transform(nullptr),
 	playerManager(nullptr), attackComboPhase(AttackCombo::IDLE), enemyDetection(nullptr), jumpFinisherScript(nullptr),
-	lightFinisherScript(nullptr), normalAttackDistance(0), heavyFinisherAttack(nullptr), bixLightSaber(nullptr),
-	isJumpAttacking(false)
+	lightFinisherScript(nullptr), normalAttackDistance(0), heavyFinisherAttack(nullptr), bixLightSaber(nullptr)
 {
 	//REGISTER_FIELD(comboInitTimer, float);
 	REGISTER_FIELD(comboCountHeavy, float);
@@ -157,7 +156,7 @@ void BixAttackScript::LightNormalAttack()
 	if(enemyAttacked != nullptr)
 	{
 		LOG_VERBOSE("Enemy hit with light attack");
-		comboSystem->SuccessfulAttack(comboCountSoft, AttackType::LIGHTNORMAL);
+		comboSystem->SuccessfulAttack(comboCountSoft, currentAttack);
 		DamageEnemy(enemyAttacked, attackSoft);
 	}
 
@@ -179,7 +178,7 @@ void BixAttackScript::HeavyNormalAttack()
 	if (enemyAttacked != nullptr)
 	{
 		LOG_VERBOSE("Enemy hit with heavy attack");
-		comboSystem->SuccessfulAttack(comboCountHeavy, AttackType::HEAVYNORMAL);
+		comboSystem->SuccessfulAttack(comboCountHeavy, currentAttack);
 		DamageEnemy(enemyAttacked, attackHeavy);
 	}
 
@@ -194,12 +193,11 @@ void BixAttackScript::JumpNormalAttack()
 {
 	animation->SetParameter("IsJumpAttacking", true);
 	isAttacking = true;
-	isJumpAttacking = true;
 
 	jumpFinisherScript->PerformGroundSmash(10.0f, 2.0f); // Bix jumping attack
 	//jumpFinisherScript->ShootForceBullet(10.0f, 2.0f); // Allura jumping attack, placed it here for now
 
-	comboSystem->SuccessfulAttack(20.0f, AttackType::JUMPNORMAL);
+	comboSystem->SuccessfulAttack(20.0f, currentAttack);
 }
 
 void BixAttackScript::LightFinisher()
@@ -209,7 +207,7 @@ void BixAttackScript::LightFinisher()
 
 	lightFinisherScript->ThrowStunItem();
 
-	comboSystem->SuccessfulAttack(-20.0f, AttackType::LIGHTFINISHER);
+	comboSystem->SuccessfulAttack(-20.0f, currentAttack);
 }
 
 void BixAttackScript::HeavyFinisher()
@@ -223,12 +221,12 @@ void BixAttackScript::HeavyFinisher()
 	{
 		heavyFinisherAttack->PerformHeavyFinisher(enemyAttacked->GetComponent<ComponentTransform>(), 
 			GetOwner()->GetComponent<ComponentTransform>());
-		comboSystem->SuccessfulAttack(-50.0f, AttackType::HEAVYFINISHER);
+		comboSystem->SuccessfulAttack(-50.0f, currentAttack);
 	}
 	else
 	{
 		heavyFinisherAttack->PerformEmptyHeavyFinisher(GetOwner()->GetComponent<ComponentTransform>());
-		comboSystem->SuccessfulAttack(-50.0f, AttackType::HEAVYFINISHER);
+		comboSystem->SuccessfulAttack(-50.0f, currentAttack);
 	}
 }
 
@@ -236,12 +234,11 @@ void BixAttackScript::JumpFinisher()
 {
 	animation->SetParameter("IsJumpAttacking", true);
 	isAttacking = true;
-	isJumpAttacking = true;
 
 	jumpFinisherScript->PerformGroundSmash(15.0f, 4.0f); // Bix jumping finisher
 	//jumpFinisherScript->ShootForceBullet(15.0f, 4.0f); // Allura jumping finisher, placed it here for now
 
-	comboSystem->SuccessfulAttack(-35.0f, AttackType::JUMPFINISHER);
+	comboSystem->SuccessfulAttack(-35.0f, currentAttack);
 }
 
 void BixAttackScript::ResetAttackAnimations()
@@ -269,7 +266,6 @@ void BixAttackScript::ResetAttackAnimations()
 			if (animation->GetActualStateName() == "BixJumpAttackRecovery" && !animation->IsPlaying())
 			{
 				isAttacking = false;
-				isJumpAttacking = false;
 			}
 			else if (animation->GetActualStateName() == "BixJumpAttack")
 			{
@@ -283,7 +279,6 @@ void BixAttackScript::ResetAttackAnimations()
 				animation->GetActualStateName() == "BixIdle3")
 			{
 				isAttacking = false;
-				isJumpAttacking = false;
 			}
 			break;	
 
@@ -328,7 +323,7 @@ bool BixAttackScript::IsAttackAvailable() const
 
 bool BixAttackScript::IsPerfomingJumpAttack() const
 {
-	return isJumpAttacking;
+	return (currentAttack == AttackType::JUMPFINISHER || currentAttack == AttackType::JUMPNORMAL);
 }
 
 bool BixAttackScript::IsDeathTouched() const
@@ -339,4 +334,14 @@ bool BixAttackScript::IsDeathTouched() const
 void BixAttackScript::SetIsDeathTouched(bool isDeathTouched)
 {
 	this->isDeathTouched = isDeathTouched;
+}
+
+AttackType BixAttackScript::GetCurrentAttackType() const
+{
+	return currentAttack;
+}
+
+GameObject* BixAttackScript::GetEnemyDetection() const
+{
+	return enemyDetection->GetEnemySelected();
 }

--- a/Game/Scripts/BixAttackScript.cpp
+++ b/Game/Scripts/BixAttackScript.cpp
@@ -341,7 +341,7 @@ AttackType BixAttackScript::GetCurrentAttackType() const
 	return currentAttack;
 }
 
-GameObject* BixAttackScript::GetEnemyDetection() const
+GameObject* BixAttackScript::GetEnemyDetected() const
 {
 	return enemyDetection->GetEnemySelected();
 }

--- a/Game/Scripts/BixAttackScript.h
+++ b/Game/Scripts/BixAttackScript.h
@@ -41,7 +41,7 @@ public:
 	bool IsPerfomingJumpAttack() const;
 
 	AttackType GetCurrentAttackType() const;
-	GameObject* GetEnemyDetection() const;
+	GameObject* GetEnemyDetected() const;
 
 private:
 	void Start() override;

--- a/Game/Scripts/BixAttackScript.h
+++ b/Game/Scripts/BixAttackScript.h
@@ -40,6 +40,9 @@ public:
 	bool IsAttackAvailable() const;
 	bool IsPerfomingJumpAttack() const;
 
+	AttackType GetCurrentAttackType() const;
+	GameObject* GetEnemyDetection() const;
+
 private:
 	void Start() override;
 	void Update(float deltaTime) override;
@@ -60,7 +63,6 @@ private:
 	void DamageEnemy(GameObject* enemyAttacked, float damageAttack);
 
 	bool isAttacking;
-	bool isJumpAttacking;
 	float attackCooldown;
 	float attackCooldownCounter;
 	float comboInitTimer;

--- a/Game/Scripts/PlayerMoveScript.cpp
+++ b/Game/Scripts/PlayerMoveScript.cpp
@@ -19,8 +19,6 @@
 #include "../Scripts/PlayerManagerScript.h"
 #include "../Scripts/PlayerForceUseScript.h"
 
-#include "debugdraw.h"
-
 #include "AxoLog.h"
 
 REGISTERCLASS(PlayerMoveScript);

--- a/Game/Scripts/PlayerMoveScript.cpp
+++ b/Game/Scripts/PlayerMoveScript.cpp
@@ -31,6 +31,8 @@ PlayerMoveScript::PlayerMoveScript() : Script(), componentTransform(nullptr),
 	REGISTER_FIELD(dashForce, float);
 	REGISTER_FIELD(canDash, bool);
 	REGISTER_FIELD(isParalyzed, bool);
+	REGISTER_FIELD(lightAttacksMoveFactor, float);
+	REGISTER_FIELD(heavyAttacksMoveFactor, float);
 }
 
 void PlayerMoveScript::Start()

--- a/Game/Scripts/PlayerMoveScript.cpp
+++ b/Game/Scripts/PlayerMoveScript.cpp
@@ -52,6 +52,8 @@ void PlayerMoveScript::Start()
 
 	previousMovements = 0;
 	currentMovements = 0;
+
+	desiredRotation = componentTransform->GetGlobalForward();
 }
 
 void PlayerMoveScript::PreUpdate(float deltaTime)

--- a/Game/Scripts/PlayerMoveScript.cpp
+++ b/Game/Scripts/PlayerMoveScript.cpp
@@ -26,7 +26,7 @@ REGISTERCLASS(PlayerMoveScript);
 PlayerMoveScript::PlayerMoveScript() : Script(), componentTransform(nullptr),
 	componentAudio(nullptr), playerState(PlayerActions::IDLE), componentAnimation(nullptr),
 	dashForce(20000.0f), nextDash(0.0f), isDashing(false), canDash(true), playerManager(nullptr), isParalyzed(false),
-	desiredRotation(0.0f, 0.0f, 0.0f)
+	desiredRotation(0.0f, 0.0f, 0.0f), lightAttacksMoveFactor(2.0f), heavyAttacksMoveFactor(3.0f)
 {
 	REGISTER_FIELD(dashForce, float);
 	REGISTER_FIELD(canDash, bool);
@@ -152,13 +152,11 @@ void PlayerMoveScript::Move(float deltaTime)
 		switch (currentAttack)
 		{
 		case AttackType::LIGHTNORMAL:
-				newSpeed = newSpeed / 2.0f;
+				newSpeed = newSpeed / lightAttacksMoveFactor;
 			break;
 		case AttackType::HEAVYNORMAL:
-			newSpeed = newSpeed / 3.0f;
-			break;
 		case AttackType::LIGHTFINISHER:
-			newSpeed = newSpeed / 3.0f;
+			newSpeed = newSpeed / heavyAttacksMoveFactor;
 			break;
 		}
 
@@ -236,7 +234,7 @@ void PlayerMoveScript::MoveRotate(float deltaTime)
 
 	//Look at enemy selected while attacking
 	AttackType currentAttack = bixAttackScript->GetCurrentAttackType();
-	GameObject* enemyGO = bixAttackScript->GetEnemyDetection();
+	GameObject* enemyGO = bixAttackScript->GetEnemyDetected();
 	if (enemyGO != nullptr && currentAttack != AttackType::NONE)
 	{
 		ComponentTransform* enemy = enemyGO->GetComponent<ComponentTransform>();
@@ -245,11 +243,7 @@ void PlayerMoveScript::MoveRotate(float deltaTime)
 		switch (currentAttack)
 		{
 		case AttackType::LIGHTNORMAL:
-			desiredRotation = vecForward + vecTowardsEnemy;
-			break;
 		case AttackType::HEAVYNORMAL:
-			desiredRotation = vecForward + vecTowardsEnemy;
-			break;
 		case AttackType::LIGHTFINISHER:
 			desiredRotation = vecForward + vecTowardsEnemy;
 			break;

--- a/Game/Scripts/PlayerMoveScript.h
+++ b/Game/Scripts/PlayerMoveScript.h
@@ -66,6 +66,9 @@ private:
     bool isDashing;
     bool canDash;
 
+    float lightAttacksMoveFactor;
+    float heavyAttacksMoveFactor;
+
 	PlayerManagerScript* playerManager;
 	PlayerForceUseScript* forceScript;
 

--- a/Game/Scripts/PlayerMoveScript.h
+++ b/Game/Scripts/PlayerMoveScript.h
@@ -45,7 +45,7 @@ public:
     void PreUpdate(float deltaTime) override;
 
     void Move(float deltaTime);
-	void MoveRotate(const float3& targetDirection, float deltaTime);
+	void MoveRotate(float deltaTime);
 
 	bool IsParalyzed() const;
 	void SetIsParalyzed(bool isParalyzed);
@@ -81,6 +81,8 @@ private:
 
 	int previousMovements;
 	int currentMovements;
+
+	float3 desiredRotation;
 	
 	void Dash();
 };


### PR DESCRIPTION
Hi! I made this changes because I felt that the attack was a little bit off. I made it without consulting so please, any change or suggestion is welcomed.

This PR makes the character look at the enemy targeted while attacking. Also, slows down the velocity movement while attacking, that's to gain more control of the character and because it felt weird moving the character while the attack animation was still.