### PR TITLE
fix: from kp to update rigidbodies

### DIFF
--- a/Game/Assets/Scenes/BixPrefab.axolotl
+++ b/Game/Assets/Scenes/BixPrefab.axolotl
@@ -146,7 +146,13 @@
                             "height": 0.699999988079071,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.6499999761581421,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -262,6 +268,16 @@
                                     "name": "IsParalyzed",
                                     "value": false,
                                     "type": 5
+                                },
+                                {
+                                    "name": "LightAttacksMoveFactor",
+                                    "value": 2.0,
+                                    "type": 0
+                                },
+                                {
+                                    "name": "HeavyAttacksMoveFactor",
+                                    "value": 3.0,
+                                    "type": 0
                                 }
                             ]
                         }
@@ -6070,7 +6086,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -6091,7 +6107,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6157,7 +6179,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 1.0,
@@ -6178,7 +6200,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": 0.2594938278198242
+                            "rbPos_Z": 0.2594938278198242,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6244,7 +6272,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -6265,7 +6293,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": 0.5999962091445923
+                            "rbPos_Z": 0.5999962091445923,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6370,7 +6404,13 @@
                             "height": 0.10000000149011612,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": 0.5999981164932251
+                            "rbPos_Z": 0.5999981164932251,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6498,7 +6538,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.7203463315963745,
-                            "rbPos_Z": 0.7461742758750916
+                            "rbPos_Z": 0.7461742758750916,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6637,7 +6683,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": 0.009493827819824219
+                            "rbPos_Z": 0.009493827819824219,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {

--- a/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
@@ -160,6 +160,11 @@
                                     "name": "YFocusOffset",
                                     "value": 0.0,
                                     "type": 0
+                                },
+                                {
+                                    "name": "InCombat",
+                                    "value": false,
+                                    "type": 5
                                 }
                             ]
                         }
@@ -229,7 +234,13 @@
                             "height": 2.0,
                             "rbPos_X": 5.567686080932617,
                             "rbPos_Y": 1.5957939624786377,
-                            "rbPos_Z": -7.999545097351074
+                            "rbPos_Z": -7.999545097351074,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -437,7 +448,13 @@
                             "height": 2.0,
                             "rbPos_X": 192.1590576171875,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -8.762855529785156,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -520,7 +537,13 @@
                             "height": 2.0,
                             "rbPos_X": 195.6409912109375,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_Z": -8.701062202453613,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -714,8 +737,13 @@
                             "positionFixedZ": 0.0,
                             "focusOffsetX": 0.0,
                             "focusOffsetY": 0.0,
-                            "isSampleFocusEnabled": false,
+                            "KpPosition": 0.0,
+                            "KpRotation": 0.0,
                             "isSampleFixedEnabled": false,
+                            "isSampleFocusEnabled": false,
+                            "isCombatCameraEnabled": false,
+                            "isSampleKpPositionEnabled": false,
+                            "isSampleKpRotationEnabled": false,
                             "positionX": 0.0,
                             "positionY": 0.0,
                             "positionZ": 62.397525787353516
@@ -786,7 +814,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": -1.500262975692749,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -862,7 +896,13 @@
                             "height": 0.699999988079071,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.6499999761581421,
-                            "rbPos_Z": -14.259493827819824
+                            "rbPos_Z": -14.259493827819824,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -978,6 +1018,16 @@
                                     "name": "IsParalyzed",
                                     "value": false,
                                     "type": 5
+                                },
+                                {
+                                    "name": "LightAttacksMoveFactor",
+                                    "value": 2.0,
+                                    "type": 0
+                                },
+                                {
+                                    "name": "HeavyAttacksMoveFactor",
+                                    "value": 3.0,
+                                    "type": 0
                                 }
                             ]
                         }
@@ -6786,7 +6836,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -6807,7 +6857,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.259493827819824
+                            "rbPos_Z": -14.259493827819824,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -7017,7 +7073,13 @@
                             "height": 2.0,
                             "rbPos_X": 192.1590576171875,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -8.762855529785156,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -7100,7 +7162,13 @@
                             "height": 2.0,
                             "rbPos_X": 195.6409912109375,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_Z": -8.701062202453613,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -7206,10 +7274,10 @@
                             "localAABB_min_y": 0.0,
                             "localAABB_max_x": 0.0,
                             "localAABB_max_y": 0.0,
-                            "worldAABB_min_x": 431.0,
-                            "worldAABB_min_y": 243.0,
-                            "worldAABB_max_x": 431.0,
-                            "worldAABB_max_y": 243.0
+                            "worldAABB_min_x": 383.5,
+                            "worldAABB_min_y": 221.0,
+                            "worldAABB_max_x": 383.5,
+                            "worldAABB_max_y": 221.0
                         }
                     },
                     {
@@ -7301,10 +7369,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7340,9 +7408,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7392,10 +7460,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7430,10 +7498,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7468,10 +7536,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7507,9 +7575,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7559,10 +7627,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7598,9 +7666,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7650,10 +7718,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7688,10 +7756,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 353.5546875,
-                            "worldAABB_min_y": 123.64574432373047,
-                            "worldAABB_max_x": 508.4453125,
-                            "worldAABB_max_y": 162.03167724609375
+                            "worldAABB_min_x": 314.58984375,
+                            "worldAABB_min_y": 114.79962921142578,
+                            "worldAABB_max_x": 452.41015625,
+                            "worldAABB_max_y": 148.95510864257813
                         }
                     },
                     {
@@ -7741,10 +7809,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 197.9040985107422,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 234.0452423095703
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 180.87405395507813,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 213.03213500976563
                         }
                     },
                     {
@@ -7866,10 +7934,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 243.1195831298828,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 279.2607421875
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 221.10638427734375,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 253.26446533203125
                         }
                     },
                     {
@@ -7991,10 +8059,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8029,10 +8097,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8067,10 +8135,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 288.33502197265625,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 324.4761962890625
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 261.3387145996094,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 293.4967956542969
                         }
                     },
                     {
@@ -8192,10 +8260,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 333.5505065917969,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 369.6916809082031
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 301.571044921875,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 333.7291259765625
                         }
                     },
                     {
@@ -8317,10 +8385,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 197.9041290283203,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 234.04527282714844
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 180.87408447265625,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 213.03216552734375
                         }
                     },
                     {
@@ -8370,10 +8438,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 243.1195831298828,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 279.2607421875
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 221.10638427734375,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 253.26446533203125
                         }
                     },
                     {
@@ -8423,10 +8491,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 288.33502197265625,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 324.4761962890625
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 261.3387145996094,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 293.4967956542969
                         }
                     },
                     {
@@ -8476,10 +8544,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 333.5505065917969,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 369.6916809082031
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 301.571044921875,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 333.7291259765625
                         }
                     },
                     {
@@ -8529,10 +8597,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8568,9 +8636,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -8620,10 +8688,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 729.6103515625,
-                            "worldAABB_min_y": 27.787521362304688,
-                            "worldAABB_max_x": 779.8936767578125,
-                            "worldAABB_max_y": 40.35835266113281
+                            "worldAABB_min_x": 649.2008056640625,
+                            "worldAABB_min_y": 29.505817413330078,
+                            "worldAABB_max_x": 693.9425048828125,
+                            "worldAABB_max_y": 40.69123458862305
                         }
                     },
                     {
@@ -8746,9 +8814,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -8798,10 +8866,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8836,10 +8904,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8874,10 +8942,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 10.527732849121094,
-                            "worldAABB_min_y": 58.83058166503906,
-                            "worldAABB_max_x": 141.39907836914063,
-                            "worldAABB_max_y": 96.76756286621094
+                            "worldAABB_min_x": 9.36749267578125,
+                            "worldAABB_min_y": 57.127681732177734,
+                            "worldAABB_max_x": 125.815673828125,
+                            "worldAABB_max_y": 90.8836669921875
                         }
                     },
                     {
@@ -8927,10 +8995,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 873.321044921875,
-                            "worldAABB_min_y": 20.990108489990234,
-                            "worldAABB_max_x": 1130.7987060546875,
-                            "worldAABB_max_y": 90.57864379882813
+                            "worldAABB_min_x": 777.0733642578125,
+                            "worldAABB_min_y": 23.457538604736328,
+                            "worldAABB_max_x": 1006.1746826171875,
+                            "worldAABB_max_y": 85.37681579589844
                         }
                     },
                     {
@@ -8997,10 +9065,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 60.5366325378418,
-                            "worldAABB_min_y": -11.928668975830078,
-                            "worldAABB_max_x": 150.3282928466797,
-                            "worldAABB_max_y": 77.86299133300781
+                            "worldAABB_min_x": 53.86494827270508,
+                            "worldAABB_min_y": -5.833278656005859,
+                            "worldAABB_max_x": 133.7607879638672,
+                            "worldAABB_max_y": 74.06256103515625
                         }
                     },
                     {
@@ -9049,10 +9117,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 10.141059875488281,
-                            "worldAABB_min_y": 5.917423248291016,
-                            "worldAABB_max_x": 200.723876953125,
-                            "worldAABB_max_y": 60.016902923583984
+                            "worldAABB_min_x": 9.023406982421875,
+                            "worldAABB_min_y": 10.046018600463867,
+                            "worldAABB_max_x": 178.60232543945313,
+                            "worldAABB_max_y": 58.183258056640625
                         }
                     },
                     {
@@ -9102,10 +9170,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 88.35577392578125,
-                            "worldAABB_min_y": 37.72309494018555,
-                            "worldAABB_max_x": 186.22869873046875,
-                            "worldAABB_max_y": 46.7022590637207
+                            "worldAABB_min_x": 78.61817932128906,
+                            "worldAABB_min_y": 38.34640884399414,
+                            "worldAABB_max_x": 165.7046356201172,
+                            "worldAABB_max_y": 46.335994720458984
                         }
                     },
                     {
@@ -9155,10 +9223,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 194.35617065429688,
-                            "worldAABB_min_y": 19.4984130859375,
-                            "worldAABB_max_x": 205.58013916015625,
-                            "worldAABB_max_y": 46.4359130859375
+                            "worldAABB_min_x": 172.93641662597656,
+                            "worldAABB_min_y": 22.130264282226563,
+                            "worldAABB_max_x": 182.9233856201172,
+                            "worldAABB_max_y": 46.09901428222656
                         }
                     },
                     {
@@ -9224,10 +9292,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 60.53666305541992,
-                            "worldAABB_min_y": -11.92886734008789,
-                            "worldAABB_max_x": 150.3283233642578,
-                            "worldAABB_max_y": 77.86279296875
+                            "worldAABB_min_x": 53.8649787902832,
+                            "worldAABB_min_y": -5.833461761474609,
+                            "worldAABB_max_x": 133.7608184814453,
+                            "worldAABB_max_y": 74.0623779296875
                         }
                     },
                     {
@@ -9276,10 +9344,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 15.640830993652344,
-                            "worldAABB_min_y": 21.74300765991211,
-                            "worldAABB_max_x": 195.22415161132813,
-                            "worldAABB_max_y": 44.190921783447266
+                            "worldAABB_min_x": 13.917060852050781,
+                            "worldAABB_min_y": 24.12747573852539,
+                            "worldAABB_max_x": 173.708740234375,
+                            "worldAABB_max_y": 44.101436614990234
                         }
                     },
                     {
@@ -9329,10 +9397,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 88.35589599609375,
-                            "worldAABB_min_y": 37.722774505615234,
-                            "worldAABB_max_x": 186.22882080078125,
-                            "worldAABB_max_y": 46.70193862915039
+                            "worldAABB_min_x": 78.61830139160156,
+                            "worldAABB_min_y": 38.346134185791016,
+                            "worldAABB_max_x": 165.7047576904297,
+                            "worldAABB_max_y": 46.33572006225586
                         }
                     },
                     {
@@ -9382,10 +9450,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 188.92872619628906,
-                            "worldAABB_min_y": 19.498214721679688,
-                            "worldAABB_max_x": 200.15269470214844,
-                            "worldAABB_max_y": 46.43571472167969
+                            "worldAABB_min_x": 168.10711669921875,
+                            "worldAABB_min_y": 22.130081176757813,
+                            "worldAABB_max_x": 178.09408569335938,
+                            "worldAABB_max_y": 46.09883117675781
                         }
                     },
                     {
@@ -9451,10 +9519,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -9489,10 +9557,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9541,10 +9609,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9594,10 +9662,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9647,10 +9715,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 723.496337890625,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 734.7203369140625,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 643.7606811523438,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 653.7476196289063,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -9716,10 +9784,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9768,10 +9836,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9821,10 +9889,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9874,10 +9942,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 775.7697143554688,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 786.9937133789063,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 690.2730712890625,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 700.260009765625,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -9943,10 +10011,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9995,10 +10063,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -10048,10 +10116,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -10101,10 +10169,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 776.1032104492188,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 787.3272094726563,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 690.56982421875,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 700.5567626953125,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -10170,10 +10238,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -10222,10 +10290,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -10275,10 +10343,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -10328,10 +10396,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 811.1874389648438,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 822.4114379882813,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 721.7874145507813,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 731.7743530273438,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -10398,7 +10466,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 1.0,
@@ -10419,7 +10487,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.0
+                            "rbPos_Z": -14.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -10647,7 +10721,13 @@
                             "height": 2.0,
                             "rbPos_X": -1.634626585200749e-7,
                             "rbPos_Y": 1.5,
-                            "rbPos_Z": 1.1187258958816528
+                            "rbPos_Z": 1.1187258958816528,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -13314,7 +13394,13 @@
                             "height": 2.0,
                             "rbPos_X": -9.122870778810466e-7,
                             "rbPos_Y": 1.0531424283981323,
-                            "rbPos_Z": 2.870622158050537
+                            "rbPos_Z": 2.870622158050537,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -13371,7 +13457,13 @@
                             "height": 2.0,
                             "rbPos_X": -5.654783308273181e-9,
                             "rbPos_Y": 1.2486436367034912,
-                            "rbPos_Z": 1.1187258958816528
+                            "rbPos_Z": 1.1187258958816528,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -13589,7 +13681,13 @@
                             "height": 2.0,
                             "rbPos_X": -1.634626585200749e-7,
                             "rbPos_Y": 1.5,
-                            "rbPos_Z": 8.457332611083984
+                            "rbPos_Z": 8.457332611083984,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -16256,7 +16354,13 @@
                             "height": 2.0,
                             "rbPos_X": -9.760116199686308e-7,
                             "rbPos_Y": 1.1267046928405762,
-                            "rbPos_Z": 10.261439323425293
+                            "rbPos_Z": 10.261439323425293,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -16313,7 +16417,13 @@
                             "height": 2.0,
                             "rbPos_X": -5.654783308273181e-9,
                             "rbPos_Y": 1.2486436367034912,
-                            "rbPos_Z": 8.457332611083984
+                            "rbPos_Z": 8.457332611083984,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -16548,7 +16658,13 @@
                             "height": 2.0,
                             "rbPos_X": -9.97762680053711,
                             "rbPos_Y": 0.9167737364768982,
-                            "rbPos_Z": 0.9055957794189453
+                            "rbPos_Z": 0.9055957794189453,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -16621,7 +16737,13 @@
                             "height": 2.0,
                             "rbPos_X": -9.97762680053711,
                             "rbPos_Y": 0.6000000238418579,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -20210,7 +20332,13 @@
                             "height": 2.0,
                             "rbPos_X": -13.030592918395996,
                             "rbPos_Y": 0.9167737364768982,
-                            "rbPos_Z": 5.935412406921387
+                            "rbPos_Z": 5.935412406921387,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -20283,7 +20411,13 @@
                             "height": 2.0,
                             "rbPos_X": -13.030592918395996,
                             "rbPos_Y": 0.6000000238418579,
-                            "rbPos_Z": 5.029816627502441
+                            "rbPos_Z": 5.029816627502441,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -23692,10 +23826,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": -6.667972564697266,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 83.12368774414063
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": -1.1523704528808594,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 78.74346923828125
                         }
                     },
                     {
@@ -23750,10 +23884,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": -6.667972564697266,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 83.12368774414063
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": -1.1523704528808594,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 78.74346923828125
                         }
                     },
                     {
@@ -23802,10 +23936,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 674.4247436523438,
-                            "worldAABB_min_y": 27.003902435302734,
-                            "worldAABB_max_x": 854.0081176757813,
-                            "worldAABB_max_y": 49.45181655883789
+                            "worldAABB_min_x": 600.0972290039063,
+                            "worldAABB_min_y": 28.80856704711914,
+                            "worldAABB_max_x": 759.8888549804688,
+                            "worldAABB_max_y": 48.782527923583984
                         }
                     },
                     {
@@ -23855,10 +23989,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 674.4247436523438,
-                            "worldAABB_min_y": 27.003902435302734,
-                            "worldAABB_max_x": 854.0081176757813,
-                            "worldAABB_max_y": 49.45181655883789
+                            "worldAABB_min_x": 600.0972290039063,
+                            "worldAABB_min_y": 28.80856704711914,
+                            "worldAABB_max_x": 759.8888549804688,
+                            "worldAABB_max_y": 48.782527923583984
                         }
                     },
                     {
@@ -23908,10 +24042,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -23946,10 +24080,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 777.1239624023438,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 866.9155883789063,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 691.4780883789063,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 771.3739624023438,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -23984,10 +24118,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 808.551025390625,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 835.488525390625,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 719.441650390625,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 743.410400390625,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -24037,10 +24171,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 721.1163940429688,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 810.9080200195313,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 641.6430053710938,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 721.5388793945313,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -24075,10 +24209,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 752.54345703125,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 779.48095703125,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 669.6065673828125,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 693.5753173828125,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -24128,10 +24262,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 664.9966430664063,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 754.7882690429688,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 591.7081298828125,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 671.60400390625,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -24166,10 +24300,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 696.4237060546875,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 723.3612060546875,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 619.6716918945313,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 643.6404418945313,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -24219,10 +24353,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 742.6664428710938,
-                            "worldAABB_min_y": 61.05739212036133,
-                            "worldAABB_max_x": 785.7664184570313,
-                            "worldAABB_max_y": 104.15739440917969
+                            "worldAABB_min_x": 660.8180541992188,
+                            "worldAABB_min_y": 59.10905456542969,
+                            "worldAABB_max_x": 699.1680297851563,
+                            "worldAABB_max_y": 97.45906066894531
                         }
                     },
                     {
@@ -24272,10 +24406,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 742.6664428710938,
-                            "worldAABB_min_y": 61.05739212036133,
-                            "worldAABB_max_x": 785.7664184570313,
-                            "worldAABB_max_y": 104.15739440917969
+                            "worldAABB_min_x": 660.8180541992188,
+                            "worldAABB_min_y": 59.10905456542969,
+                            "worldAABB_max_x": 699.1680297851563,
+                            "worldAABB_max_y": 97.45906066894531
                         }
                     },
                     {
@@ -24326,7 +24460,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -24347,7 +24481,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": -13.659497261047363
+                            "rbPos_Z": -13.659497261047363,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -24452,7 +24592,13 @@
                             "height": 0.10000000149011612,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": -13.65949535369873
+                            "rbPos_Z": -13.65949535369873,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -24580,7 +24726,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.7203463315963745,
-                            "rbPos_Z": -13.513319969177246
+                            "rbPos_Z": -13.513319969177246,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -24719,7 +24871,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.25
+                            "rbPos_Z": -14.25,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {

--- a/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_VS3.axolotl
@@ -7274,10 +7274,10 @@
                             "localAABB_min_y": 0.0,
                             "localAABB_max_x": 0.0,
                             "localAABB_max_y": 0.0,
-                            "worldAABB_min_x": 383.5,
-                            "worldAABB_min_y": 221.0,
-                            "worldAABB_max_x": 383.5,
-                            "worldAABB_max_y": 221.0
+                            "worldAABB_min_x": 358.5,
+                            "worldAABB_min_y": 245.0,
+                            "worldAABB_max_x": 358.5,
+                            "worldAABB_max_y": 245.0
                         }
                     },
                     {
@@ -7369,10 +7369,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7408,9 +7408,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 5.28125,
-                            "worldAABB_max_x": 767.0,
-                            "worldAABB_max_y": 436.71875
+                            "worldAABB_min_y": 43.34375,
+                            "worldAABB_max_x": 717.0,
+                            "worldAABB_max_y": 446.65625
                         }
                     },
                     {
@@ -7460,10 +7460,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7498,10 +7498,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7536,10 +7536,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7575,9 +7575,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 5.28125,
-                            "worldAABB_max_x": 767.0,
-                            "worldAABB_max_y": 436.71875
+                            "worldAABB_min_y": 43.34375,
+                            "worldAABB_max_x": 717.0,
+                            "worldAABB_max_y": 446.65625
                         }
                     },
                     {
@@ -7627,10 +7627,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7666,9 +7666,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 5.28125,
-                            "worldAABB_max_x": 767.0,
-                            "worldAABB_max_y": 436.71875
+                            "worldAABB_min_y": 43.34375,
+                            "worldAABB_max_x": 717.0,
+                            "worldAABB_max_y": 446.65625
                         }
                     },
                     {
@@ -7718,10 +7718,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -7756,10 +7756,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 314.58984375,
-                            "worldAABB_min_y": 114.79962921142578,
-                            "worldAABB_max_x": 452.41015625,
-                            "worldAABB_max_y": 148.95510864257813
+                            "worldAABB_min_x": 294.08203125,
+                            "worldAABB_min_y": 145.72274780273438,
+                            "worldAABB_max_x": 422.91796875,
+                            "worldAABB_max_y": 177.65164184570313
                         }
                     },
                     {
@@ -7809,10 +7809,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 180.87405395507813,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 213.03213500976563
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 207.48983764648438,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 237.55154418945313
                         }
                     },
                     {
@@ -7934,10 +7934,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 221.10638427734375,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 253.26446533203125
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 245.09945678710938,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 275.1611633300781
                         }
                     },
                     {
@@ -8059,10 +8059,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -8097,10 +8097,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -8135,10 +8135,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 261.3387145996094,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 293.4967956542969
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 282.7090759277344,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 312.7707824707031
                         }
                     },
                     {
@@ -8260,10 +8260,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 301.571044921875,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 333.7291259765625
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 320.3186950683594,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 350.3804016113281
                         }
                     },
                     {
@@ -8385,10 +8385,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 180.87408447265625,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 213.03216552734375
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 207.4898681640625,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 237.55157470703125
                         }
                     },
                     {
@@ -8438,10 +8438,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 221.10638427734375,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 253.26446533203125
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 245.09945678710938,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 275.1611633300781
                         }
                     },
                     {
@@ -8491,10 +8491,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 261.3387145996094,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 293.4967956542969
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 282.7090759277344,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 312.7707824707031
                         }
                     },
                     {
@@ -8544,10 +8544,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 330.2694091796875,
-                            "worldAABB_min_y": 301.571044921875,
-                            "worldAABB_max_x": 436.7305908203125,
-                            "worldAABB_max_y": 333.7291259765625
+                            "worldAABB_min_x": 308.73944091796875,
+                            "worldAABB_min_y": 320.3186950683594,
+                            "worldAABB_max_x": 408.26055908203125,
+                            "worldAABB_max_y": 350.3804016113281
                         }
                     },
                     {
@@ -8597,10 +8597,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -8636,9 +8636,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 5.28125,
-                            "worldAABB_max_x": 767.0,
-                            "worldAABB_max_y": 436.71875
+                            "worldAABB_min_y": 43.34375,
+                            "worldAABB_max_x": 717.0,
+                            "worldAABB_max_y": 446.65625
                         }
                     },
                     {
@@ -8688,10 +8688,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 649.2008056640625,
-                            "worldAABB_min_y": 29.505817413330078,
-                            "worldAABB_max_x": 693.9425048828125,
-                            "worldAABB_max_y": 40.69123458862305
+                            "worldAABB_min_x": 606.880126953125,
+                            "worldAABB_min_y": 65.9891586303711,
+                            "worldAABB_max_x": 648.705078125,
+                            "worldAABB_max_y": 76.4454116821289
                         }
                     },
                     {
@@ -8814,9 +8814,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 5.28125,
-                            "worldAABB_max_x": 767.0,
-                            "worldAABB_max_y": 436.71875
+                            "worldAABB_min_y": 43.34375,
+                            "worldAABB_max_x": 717.0,
+                            "worldAABB_max_y": 446.65625
                         }
                     },
                     {
@@ -8866,10 +8866,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -8904,10 +8904,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -8942,10 +8942,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 9.36749267578125,
-                            "worldAABB_min_y": 57.127681732177734,
-                            "worldAABB_max_x": 125.815673828125,
-                            "worldAABB_max_y": 90.8836669921875
+                            "worldAABB_min_x": 8.756847381591797,
+                            "worldAABB_min_y": 91.81037139892578,
+                            "worldAABB_max_x": 117.61387634277344,
+                            "worldAABB_max_y": 123.36583709716797
                         }
                     },
                     {
@@ -8995,10 +8995,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 777.0733642578125,
-                            "worldAABB_min_y": 23.457538604736328,
-                            "worldAABB_max_x": 1006.1746826171875,
-                            "worldAABB_max_y": 85.37681579589844
+                            "worldAABB_min_x": 726.4166870117188,
+                            "worldAABB_min_y": 60.33515930175781,
+                            "worldAABB_max_x": 940.5830688476563,
+                            "worldAABB_max_y": 118.21797180175781
                         }
                     },
                     {
@@ -9065,10 +9065,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 53.86494827270508,
-                            "worldAABB_min_y": -5.833278656005859,
-                            "worldAABB_max_x": 133.7607879638672,
-                            "worldAABB_max_y": 74.06256103515625
+                            "worldAABB_min_x": 50.353546142578125,
+                            "worldAABB_min_y": 32.953765869140625,
+                            "worldAABB_max_x": 125.04104614257813,
+                            "worldAABB_max_y": 107.64126586914063
                         }
                     },
                     {
@@ -9117,10 +9117,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 9.023406982421875,
-                            "worldAABB_min_y": 10.046018600463867,
-                            "worldAABB_max_x": 178.60232543945313,
-                            "worldAABB_max_y": 58.183258056640625
+                            "worldAABB_min_x": 8.435188293457031,
+                            "worldAABB_min_y": 47.79790496826172,
+                            "worldAABB_max_x": 166.95941162109375,
+                            "worldAABB_max_y": 92.79712677001953
                         }
                     },
                     {
@@ -9170,10 +9170,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 78.61817932128906,
-                            "worldAABB_min_y": 38.34640884399414,
-                            "worldAABB_max_x": 165.7046356201172,
-                            "worldAABB_max_y": 46.335994720458984
+                            "worldAABB_min_x": 73.4931640625,
+                            "worldAABB_min_y": 74.25343322753906,
+                            "worldAABB_max_x": 154.90252685546875,
+                            "worldAABB_max_y": 81.72218322753906
                         }
                     },
                     {
@@ -9223,10 +9223,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 172.93641662597656,
-                            "worldAABB_min_y": 22.130264282226563,
-                            "worldAABB_max_x": 182.9233856201172,
-                            "worldAABB_max_y": 46.09901428222656
+                            "worldAABB_min_x": 161.66285705566406,
+                            "worldAABB_min_y": 59.094390869140625,
+                            "worldAABB_max_x": 170.99879455566406,
+                            "worldAABB_max_y": 81.50064086914063
                         }
                     },
                     {
@@ -9292,10 +9292,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 53.8649787902832,
-                            "worldAABB_min_y": -5.833461761474609,
-                            "worldAABB_max_x": 133.7608184814453,
-                            "worldAABB_max_y": 74.0623779296875
+                            "worldAABB_min_x": 50.35357666015625,
+                            "worldAABB_min_y": 32.95359802246094,
+                            "worldAABB_max_x": 125.04107666015625,
+                            "worldAABB_max_y": 107.64109802246094
                         }
                     },
                     {
@@ -9344,10 +9344,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 13.917060852050781,
-                            "worldAABB_min_y": 24.12747573852539,
-                            "worldAABB_max_x": 173.708740234375,
-                            "worldAABB_max_y": 44.101436614990234
+                            "worldAABB_min_x": 13.00982666015625,
+                            "worldAABB_min_y": 60.96141052246094,
+                            "worldAABB_max_x": 162.38482666015625,
+                            "worldAABB_max_y": 79.63328552246094
                         }
                     },
                     {
@@ -9397,10 +9397,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 78.61830139160156,
-                            "worldAABB_min_y": 38.346134185791016,
-                            "worldAABB_max_x": 165.7047576904297,
-                            "worldAABB_max_y": 46.33572006225586
+                            "worldAABB_min_x": 73.49325561523438,
+                            "worldAABB_min_y": 74.253173828125,
+                            "worldAABB_max_x": 154.90261840820313,
+                            "worldAABB_max_y": 81.721923828125
                         }
                     },
                     {
@@ -9450,10 +9450,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 168.10711669921875,
-                            "worldAABB_min_y": 22.130081176757813,
-                            "worldAABB_max_x": 178.09408569335938,
-                            "worldAABB_max_y": 46.09883117675781
+                            "worldAABB_min_x": 157.14837646484375,
+                            "worldAABB_min_y": 59.09422302246094,
+                            "worldAABB_max_x": 166.48431396484375,
+                            "worldAABB_max_y": 81.50047302246094
                         }
                     },
                     {
@@ -9519,10 +9519,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 343.5520935058594,
-                            "worldAABB_min_y": 181.0520782470703,
-                            "worldAABB_max_x": 423.4479064941406,
-                            "worldAABB_max_y": 260.9479064941406
+                            "worldAABB_min_x": 321.15625,
+                            "worldAABB_min_y": 207.65625,
+                            "worldAABB_max_x": 395.84375,
+                            "worldAABB_max_y": 282.34375
                         }
                     }
                 ]
@@ -9557,10 +9557,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 608.8062133789063,
-                            "worldAABB_min_y": 332.85418701171875,
-                            "worldAABB_max_x": 688.7020874023438,
-                            "worldAABB_max_y": 412.75
+                            "worldAABB_min_x": 569.1187744140625,
+                            "worldAABB_min_y": 349.5625,
+                            "worldAABB_max_x": 643.8062744140625,
+                            "worldAABB_max_y": 424.25
                         }
                     },
                     {
@@ -9609,10 +9609,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -9662,10 +9662,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -9715,10 +9715,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 643.7606811523438,
-                            "worldAABB_min_y": 360.8177185058594,
-                            "worldAABB_max_x": 653.7476196289063,
-                            "worldAABB_max_y": 384.7864685058594
+                            "worldAABB_min_x": 601.7945556640625,
+                            "worldAABB_min_y": 375.703125,
+                            "worldAABB_max_x": 611.1304931640625,
+                            "worldAABB_max_y": 398.109375
                         }
                     },
                     {
@@ -9784,10 +9784,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 608.8062133789063,
-                            "worldAABB_min_y": 332.85418701171875,
-                            "worldAABB_max_x": 688.7020874023438,
-                            "worldAABB_max_y": 412.75
+                            "worldAABB_min_x": 569.1187744140625,
+                            "worldAABB_min_y": 349.5625,
+                            "worldAABB_max_x": 643.8062744140625,
+                            "worldAABB_max_y": 424.25
                         }
                     },
                     {
@@ -9836,10 +9836,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -9889,10 +9889,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -9942,10 +9942,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 690.2730712890625,
-                            "worldAABB_min_y": 360.8177185058594,
-                            "worldAABB_max_x": 700.260009765625,
-                            "worldAABB_max_y": 384.7864685058594
+                            "worldAABB_min_x": 645.2747802734375,
+                            "worldAABB_min_y": 375.703125,
+                            "worldAABB_max_x": 654.6107177734375,
+                            "worldAABB_max_y": 398.109375
                         }
                     },
                     {
@@ -10011,10 +10011,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 608.8062133789063,
-                            "worldAABB_min_y": 332.85418701171875,
-                            "worldAABB_max_x": 688.7020874023438,
-                            "worldAABB_max_y": 412.75
+                            "worldAABB_min_x": 569.1187744140625,
+                            "worldAABB_min_y": 349.5625,
+                            "worldAABB_max_x": 643.8062744140625,
+                            "worldAABB_max_y": 424.25
                         }
                     },
                     {
@@ -10063,10 +10063,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -10116,10 +10116,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -10169,10 +10169,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 690.56982421875,
-                            "worldAABB_min_y": 360.8177185058594,
-                            "worldAABB_max_x": 700.5567626953125,
-                            "worldAABB_max_y": 384.7864685058594
+                            "worldAABB_min_x": 645.5521850585938,
+                            "worldAABB_min_y": 375.703125,
+                            "worldAABB_max_x": 654.8881225585938,
+                            "worldAABB_max_y": 398.109375
                         }
                     },
                     {
@@ -10238,10 +10238,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 608.8062133789063,
-                            "worldAABB_min_y": 332.85418701171875,
-                            "worldAABB_max_x": 688.7020874023438,
-                            "worldAABB_max_y": 412.75
+                            "worldAABB_min_x": 569.1187744140625,
+                            "worldAABB_min_y": 349.5625,
+                            "worldAABB_max_x": 643.8062744140625,
+                            "worldAABB_max_y": 424.25
                         }
                     },
                     {
@@ -10290,10 +10290,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -10343,10 +10343,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 601.6156005859375,
-                            "worldAABB_min_y": 325.6635437011719,
-                            "worldAABB_max_x": 695.8927001953125,
-                            "worldAABB_max_y": 419.9406433105469
+                            "worldAABB_min_x": 562.3969116210938,
+                            "worldAABB_min_y": 342.84063720703125,
+                            "worldAABB_max_x": 650.5281372070313,
+                            "worldAABB_max_y": 430.97186279296875
                         }
                     },
                     {
@@ -10396,10 +10396,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 721.7874145507813,
-                            "worldAABB_min_y": 360.8177185058594,
-                            "worldAABB_max_x": 731.7743530273438,
-                            "worldAABB_max_y": 384.7864685058594
+                            "worldAABB_min_x": 674.7347412109375,
+                            "worldAABB_min_y": 375.703125,
+                            "worldAABB_max_x": 684.0706787109375,
+                            "worldAABB_max_y": 398.109375
                         }
                     },
                     {
@@ -13436,7 +13436,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -16396,7 +16396,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -23826,10 +23826,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 640.0451049804688,
-                            "worldAABB_min_y": -1.1523704528808594,
-                            "worldAABB_max_x": 719.9409790039063,
-                            "worldAABB_max_y": 78.74346923828125
+                            "worldAABB_min_x": 598.3211669921875,
+                            "worldAABB_min_y": 37.32954406738281,
+                            "worldAABB_max_x": 673.0086669921875,
+                            "worldAABB_max_y": 112.01704406738281
                         }
                     },
                     {
@@ -23884,10 +23884,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 640.0451049804688,
-                            "worldAABB_min_y": -1.1523704528808594,
-                            "worldAABB_max_x": 719.9409790039063,
-                            "worldAABB_max_y": 78.74346923828125
+                            "worldAABB_min_x": 598.3211669921875,
+                            "worldAABB_min_y": 37.32954406738281,
+                            "worldAABB_max_x": 673.0086669921875,
+                            "worldAABB_max_y": 112.01704406738281
                         }
                     },
                     {
@@ -23936,10 +23936,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 600.0972290039063,
-                            "worldAABB_min_y": 28.80856704711914,
-                            "worldAABB_max_x": 759.8888549804688,
-                            "worldAABB_max_y": 48.782527923583984
+                            "worldAABB_min_x": 560.9774169921875,
+                            "worldAABB_min_y": 65.33735656738281,
+                            "worldAABB_max_x": 710.3524169921875,
+                            "worldAABB_max_y": 84.00923156738281
                         }
                     },
                     {
@@ -23989,10 +23989,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 600.0972290039063,
-                            "worldAABB_min_y": 28.80856704711914,
-                            "worldAABB_max_x": 759.8888549804688,
-                            "worldAABB_max_y": 48.782527923583984
+                            "worldAABB_min_x": 560.9774169921875,
+                            "worldAABB_min_y": 65.33735656738281,
+                            "worldAABB_max_x": 710.3524169921875,
+                            "worldAABB_max_y": 84.00923156738281
                         }
                     },
                     {
@@ -24042,10 +24042,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 640.0451049804688,
-                            "worldAABB_min_y": 38.33613967895508,
-                            "worldAABB_max_x": 719.9409790039063,
-                            "worldAABB_max_y": 118.23197937011719
+                            "worldAABB_min_x": 598.3211669921875,
+                            "worldAABB_min_y": 74.24383544921875,
+                            "worldAABB_max_x": 673.0086669921875,
+                            "worldAABB_max_y": 148.93133544921875
                         }
                     }
                 ]
@@ -24080,10 +24080,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 691.4780883789063,
-                            "worldAABB_min_y": 38.33613967895508,
-                            "worldAABB_max_x": 771.3739624023438,
-                            "worldAABB_max_y": 118.23197937011719
+                            "worldAABB_min_x": 646.4012451171875,
+                            "worldAABB_min_y": 74.24383544921875,
+                            "worldAABB_max_x": 721.0887451171875,
+                            "worldAABB_max_y": 148.93133544921875
                         }
                     }
                 ]
@@ -24118,10 +24118,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.441650390625,
-                            "worldAABB_min_y": 66.2996826171875,
-                            "worldAABB_max_x": 743.410400390625,
-                            "worldAABB_max_y": 90.2684326171875
+                            "worldAABB_min_x": 672.5418701171875,
+                            "worldAABB_min_y": 100.38446044921875,
+                            "worldAABB_max_x": 694.9481201171875,
+                            "worldAABB_max_y": 122.79071044921875
                         }
                     },
                     {
@@ -24171,10 +24171,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 641.6430053710938,
-                            "worldAABB_min_y": 38.33613967895508,
-                            "worldAABB_max_x": 721.5388793945313,
-                            "worldAABB_max_y": 118.23197937011719
+                            "worldAABB_min_x": 599.81494140625,
+                            "worldAABB_min_y": 74.24383544921875,
+                            "worldAABB_max_x": 674.50244140625,
+                            "worldAABB_max_y": 148.93133544921875
                         }
                     }
                 ]
@@ -24209,10 +24209,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 669.6065673828125,
-                            "worldAABB_min_y": 66.2996826171875,
-                            "worldAABB_max_x": 693.5753173828125,
-                            "worldAABB_max_y": 90.2684326171875
+                            "worldAABB_min_x": 625.95556640625,
+                            "worldAABB_min_y": 100.38446044921875,
+                            "worldAABB_max_x": 648.36181640625,
+                            "worldAABB_max_y": 122.79071044921875
                         }
                     },
                     {
@@ -24262,10 +24262,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 591.7081298828125,
-                            "worldAABB_min_y": 38.33613967895508,
-                            "worldAABB_max_x": 671.60400390625,
-                            "worldAABB_max_y": 118.23197937011719
+                            "worldAABB_min_x": 553.13525390625,
+                            "worldAABB_min_y": 74.24383544921875,
+                            "worldAABB_max_x": 627.82275390625,
+                            "worldAABB_max_y": 148.93133544921875
                         }
                     }
                 ]
@@ -24300,10 +24300,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 619.6716918945313,
-                            "worldAABB_min_y": 66.2996826171875,
-                            "worldAABB_max_x": 643.6404418945313,
-                            "worldAABB_max_y": 90.2684326171875
+                            "worldAABB_min_x": 579.27587890625,
+                            "worldAABB_min_y": 100.38446044921875,
+                            "worldAABB_max_x": 601.68212890625,
+                            "worldAABB_max_y": 122.79071044921875
                         }
                     },
                     {
@@ -24353,10 +24353,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 660.8180541992188,
-                            "worldAABB_min_y": 59.10905456542969,
-                            "worldAABB_max_x": 699.1680297851563,
-                            "worldAABB_max_y": 97.45906066894531
+                            "worldAABB_min_x": 617.7399291992188,
+                            "worldAABB_min_y": 93.66258239746094,
+                            "worldAABB_max_x": 653.5899047851563,
+                            "worldAABB_max_y": 129.51258850097656
                         }
                     },
                     {
@@ -24406,10 +24406,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 660.8180541992188,
-                            "worldAABB_min_y": 59.10905456542969,
-                            "worldAABB_max_x": 699.1680297851563,
-                            "worldAABB_max_y": 97.45906066894531
+                            "worldAABB_min_x": 617.7399291992188,
+                            "worldAABB_min_y": 93.66258239746094,
+                            "worldAABB_max_x": 653.5899047851563,
+                            "worldAABB_max_y": 129.51258850097656
                         }
                     },
                     {

--- a/Game/Assets/Scenes/GameplayFullTrial_Without_enemies.axolotl
+++ b/Game/Assets/Scenes/GameplayFullTrial_Without_enemies.axolotl
@@ -160,6 +160,11 @@
                                     "name": "YFocusOffset",
                                     "value": 0.0,
                                     "type": 0
+                                },
+                                {
+                                    "name": "InCombat",
+                                    "value": false,
+                                    "type": 5
                                 }
                             ]
                         }
@@ -229,7 +234,13 @@
                             "height": 2.0,
                             "rbPos_X": 5.567686080932617,
                             "rbPos_Y": 1.5957939624786377,
-                            "rbPos_Z": -7.999545097351074
+                            "rbPos_Z": -7.999545097351074,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -297,7 +308,13 @@
                             "height": 2.0,
                             "rbPos_X": 192.1590576171875,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -8.762855529785156,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -380,7 +397,13 @@
                             "height": 2.0,
                             "rbPos_X": 195.6409912109375,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_Z": -8.701062202453613,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -574,8 +597,13 @@
                             "positionFixedZ": 0.0,
                             "focusOffsetX": 0.0,
                             "focusOffsetY": 0.0,
-                            "isSampleFocusEnabled": false,
+                            "KpPosition": 0.0,
+                            "KpRotation": 0.0,
                             "isSampleFixedEnabled": false,
+                            "isSampleFocusEnabled": false,
+                            "isCombatCameraEnabled": false,
+                            "isSampleKpPositionEnabled": false,
+                            "isSampleKpRotationEnabled": false,
                             "positionX": 0.0,
                             "positionY": 0.0,
                             "positionZ": 62.397525787353516
@@ -646,7 +674,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": -1.500262975692749,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -722,7 +756,13 @@
                             "height": 0.699999988079071,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.6499999761581421,
-                            "rbPos_Z": -14.259493827819824
+                            "rbPos_Z": -14.259493827819824,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -838,6 +878,16 @@
                                     "name": "IsParalyzed",
                                     "value": false,
                                     "type": 5
+                                },
+                                {
+                                    "name": "LightAttacksMoveFactor",
+                                    "value": 2.0,
+                                    "type": 0
+                                },
+                                {
+                                    "name": "HeavyAttacksMoveFactor",
+                                    "value": 3.0,
+                                    "type": 0
                                 }
                             ]
                         }
@@ -6646,7 +6696,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -6667,7 +6717,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.259493827819824
+                            "rbPos_Z": -14.259493827819824,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6765,7 +6821,13 @@
                             "height": 2.0,
                             "rbPos_X": 192.1590576171875,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.762855529785156
+                            "rbPos_Z": -8.762855529785156,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6848,7 +6910,13 @@
                             "height": 2.0,
                             "rbPos_X": 195.6409912109375,
                             "rbPos_Y": 3.2121219635009766,
-                            "rbPos_Z": -8.701062202453613
+                            "rbPos_Z": -8.701062202453613,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -6898,10 +6966,10 @@
                             "localAABB_min_y": 0.0,
                             "localAABB_max_x": 0.0,
                             "localAABB_max_y": 0.0,
-                            "worldAABB_min_x": 431.0,
-                            "worldAABB_min_y": 243.0,
-                            "worldAABB_max_x": 431.0,
-                            "worldAABB_max_y": 243.0
+                            "worldAABB_min_x": 383.5,
+                            "worldAABB_min_y": 221.0,
+                            "worldAABB_max_x": 383.5,
+                            "worldAABB_max_y": 221.0
                         }
                     },
                     {
@@ -6993,10 +7061,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7032,9 +7100,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7084,10 +7152,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7122,10 +7190,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7160,10 +7228,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7199,9 +7267,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7251,10 +7319,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7290,9 +7358,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -7342,10 +7410,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7380,10 +7448,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 353.5546875,
-                            "worldAABB_min_y": 123.64574432373047,
-                            "worldAABB_max_x": 508.4453125,
-                            "worldAABB_max_y": 162.03167724609375
+                            "worldAABB_min_x": 314.58984375,
+                            "worldAABB_min_y": 114.79962921142578,
+                            "worldAABB_max_x": 452.41015625,
+                            "worldAABB_max_y": 148.95510864257813
                         }
                     },
                     {
@@ -7433,10 +7501,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 197.9040985107422,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 234.0452423095703
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 180.87405395507813,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 213.03213500976563
                         }
                     },
                     {
@@ -7558,10 +7626,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 243.1195831298828,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 279.2607421875
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 221.10638427734375,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 253.26446533203125
                         }
                     },
                     {
@@ -7683,10 +7751,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7721,10 +7789,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -7759,10 +7827,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 288.33502197265625,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 324.4761962890625
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 261.3387145996094,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 293.4967956542969
                         }
                     },
                     {
@@ -7884,10 +7952,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 333.5505065917969,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 369.6916809082031
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 301.571044921875,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 333.7291259765625
                         }
                     },
                     {
@@ -8009,10 +8077,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 197.9041290283203,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 234.04527282714844
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 180.87408447265625,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 213.03216552734375
                         }
                     },
                     {
@@ -8062,10 +8130,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 243.1195831298828,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 279.2607421875
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 221.10638427734375,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 253.26446533203125
                         }
                     },
                     {
@@ -8115,10 +8183,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 288.33502197265625,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 324.4761962890625
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 261.3387145996094,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 293.4967956542969
                         }
                     },
                     {
@@ -8168,10 +8236,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 371.1763000488281,
-                            "worldAABB_min_y": 333.5505065917969,
-                            "worldAABB_max_x": 490.8236999511719,
-                            "worldAABB_max_y": 369.6916809082031
+                            "worldAABB_min_x": 330.2694091796875,
+                            "worldAABB_min_y": 301.571044921875,
+                            "worldAABB_max_x": 436.7305908203125,
+                            "worldAABB_max_y": 333.7291259765625
                         }
                     },
                     {
@@ -8221,10 +8289,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8260,9 +8328,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -8312,10 +8380,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 729.6103515625,
-                            "worldAABB_min_y": 27.787521362304688,
-                            "worldAABB_max_x": 779.8936767578125,
-                            "worldAABB_max_y": 40.35835266113281
+                            "worldAABB_min_x": 649.2008056640625,
+                            "worldAABB_min_y": 29.505817413330078,
+                            "worldAABB_max_x": 693.9425048828125,
+                            "worldAABB_max_y": 40.69123458862305
                         }
                     },
                     {
@@ -8438,9 +8506,9 @@
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
                             "worldAABB_min_x": 0.0,
-                            "worldAABB_min_y": 0.5625,
-                            "worldAABB_max_x": 862.0,
-                            "worldAABB_max_y": 485.4375
+                            "worldAABB_min_y": 5.28125,
+                            "worldAABB_max_x": 767.0,
+                            "worldAABB_max_y": 436.71875
                         }
                     },
                     {
@@ -8490,10 +8558,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8528,10 +8596,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -8566,10 +8634,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 10.527732849121094,
-                            "worldAABB_min_y": 58.83058166503906,
-                            "worldAABB_max_x": 141.39907836914063,
-                            "worldAABB_max_y": 96.76756286621094
+                            "worldAABB_min_x": 9.36749267578125,
+                            "worldAABB_min_y": 57.127681732177734,
+                            "worldAABB_max_x": 125.815673828125,
+                            "worldAABB_max_y": 90.8836669921875
                         }
                     },
                     {
@@ -8619,10 +8687,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 873.321044921875,
-                            "worldAABB_min_y": 20.990108489990234,
-                            "worldAABB_max_x": 1130.7987060546875,
-                            "worldAABB_max_y": 90.57864379882813
+                            "worldAABB_min_x": 777.0733642578125,
+                            "worldAABB_min_y": 23.457538604736328,
+                            "worldAABB_max_x": 1006.1746826171875,
+                            "worldAABB_max_y": 85.37681579589844
                         }
                     },
                     {
@@ -8689,10 +8757,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 60.5366325378418,
-                            "worldAABB_min_y": -11.928668975830078,
-                            "worldAABB_max_x": 150.3282928466797,
-                            "worldAABB_max_y": 77.86299133300781
+                            "worldAABB_min_x": 53.86494827270508,
+                            "worldAABB_min_y": -5.833278656005859,
+                            "worldAABB_max_x": 133.7607879638672,
+                            "worldAABB_max_y": 74.06256103515625
                         }
                     },
                     {
@@ -8741,10 +8809,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 10.141059875488281,
-                            "worldAABB_min_y": 5.917423248291016,
-                            "worldAABB_max_x": 200.723876953125,
-                            "worldAABB_max_y": 60.016902923583984
+                            "worldAABB_min_x": 9.023406982421875,
+                            "worldAABB_min_y": 10.046018600463867,
+                            "worldAABB_max_x": 178.60232543945313,
+                            "worldAABB_max_y": 58.183258056640625
                         }
                     },
                     {
@@ -8794,10 +8862,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 88.35577392578125,
-                            "worldAABB_min_y": 37.72309494018555,
-                            "worldAABB_max_x": 186.22869873046875,
-                            "worldAABB_max_y": 46.7022590637207
+                            "worldAABB_min_x": 78.61817932128906,
+                            "worldAABB_min_y": 38.34640884399414,
+                            "worldAABB_max_x": 165.7046356201172,
+                            "worldAABB_max_y": 46.335994720458984
                         }
                     },
                     {
@@ -8847,10 +8915,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 194.35617065429688,
-                            "worldAABB_min_y": 19.4984130859375,
-                            "worldAABB_max_x": 205.58013916015625,
-                            "worldAABB_max_y": 46.4359130859375
+                            "worldAABB_min_x": 172.93641662597656,
+                            "worldAABB_min_y": 22.130264282226563,
+                            "worldAABB_max_x": 182.9233856201172,
+                            "worldAABB_max_y": 46.09901428222656
                         }
                     },
                     {
@@ -8916,10 +8984,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 60.53666305541992,
-                            "worldAABB_min_y": -11.92886734008789,
-                            "worldAABB_max_x": 150.3283233642578,
-                            "worldAABB_max_y": 77.86279296875
+                            "worldAABB_min_x": 53.8649787902832,
+                            "worldAABB_min_y": -5.833461761474609,
+                            "worldAABB_max_x": 133.7608184814453,
+                            "worldAABB_max_y": 74.0623779296875
                         }
                     },
                     {
@@ -8968,10 +9036,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 15.640830993652344,
-                            "worldAABB_min_y": 21.74300765991211,
-                            "worldAABB_max_x": 195.22415161132813,
-                            "worldAABB_max_y": 44.190921783447266
+                            "worldAABB_min_x": 13.917060852050781,
+                            "worldAABB_min_y": 24.12747573852539,
+                            "worldAABB_max_x": 173.708740234375,
+                            "worldAABB_max_y": 44.101436614990234
                         }
                     },
                     {
@@ -9021,10 +9089,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 88.35589599609375,
-                            "worldAABB_min_y": 37.722774505615234,
-                            "worldAABB_max_x": 186.22882080078125,
-                            "worldAABB_max_y": 46.70193862915039
+                            "worldAABB_min_x": 78.61830139160156,
+                            "worldAABB_min_y": 38.346134185791016,
+                            "worldAABB_max_x": 165.7047576904297,
+                            "worldAABB_max_y": 46.33572006225586
                         }
                     },
                     {
@@ -9074,10 +9142,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 188.92872619628906,
-                            "worldAABB_min_y": 19.498214721679688,
-                            "worldAABB_max_x": 200.15269470214844,
-                            "worldAABB_max_y": 46.43571472167969
+                            "worldAABB_min_x": 168.10711669921875,
+                            "worldAABB_min_y": 22.130081176757813,
+                            "worldAABB_max_x": 178.09408569335938,
+                            "worldAABB_max_y": 46.09883117675781
                         }
                     },
                     {
@@ -9143,10 +9211,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 386.1041564941406,
-                            "worldAABB_min_y": 198.1041717529297,
-                            "worldAABB_max_x": 475.8958435058594,
-                            "worldAABB_max_y": 287.8958435058594
+                            "worldAABB_min_x": 343.5520935058594,
+                            "worldAABB_min_y": 181.0520782470703,
+                            "worldAABB_max_x": 423.4479064941406,
+                            "worldAABB_max_y": 260.9479064941406
                         }
                     }
                 ]
@@ -9181,10 +9249,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9233,10 +9301,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9286,10 +9354,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9339,10 +9407,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 723.496337890625,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 734.7203369140625,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 643.7606811523438,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 653.7476196289063,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -9408,10 +9476,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9460,10 +9528,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9513,10 +9581,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9566,10 +9634,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 775.7697143554688,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 786.9937133789063,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 690.2730712890625,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 700.260009765625,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -9635,10 +9703,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9687,10 +9755,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9740,10 +9808,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9793,10 +9861,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 776.1032104492188,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 787.3272094726563,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 690.56982421875,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 700.5567626953125,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -9862,10 +9930,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 684.2125244140625,
-                            "worldAABB_min_y": 368.7083435058594,
-                            "worldAABB_max_x": 774.004150390625,
-                            "worldAABB_max_y": 458.5000305175781
+                            "worldAABB_min_x": 608.8062133789063,
+                            "worldAABB_min_y": 332.85418701171875,
+                            "worldAABB_max_x": 688.7020874023438,
+                            "worldAABB_max_y": 412.75
                         }
                     },
                     {
@@ -9914,10 +9982,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -9967,10 +10035,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 676.1312255859375,
-                            "worldAABB_min_y": 360.6271057128906,
-                            "worldAABB_max_x": 782.08544921875,
-                            "worldAABB_max_y": 466.5812683105469
+                            "worldAABB_min_x": 601.6156005859375,
+                            "worldAABB_min_y": 325.6635437011719,
+                            "worldAABB_max_x": 695.8927001953125,
+                            "worldAABB_max_y": 419.9406433105469
                         }
                     },
                     {
@@ -10020,10 +10088,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 811.1874389648438,
-                            "worldAABB_min_y": 400.13543701171875,
-                            "worldAABB_max_x": 822.4114379882813,
-                            "worldAABB_max_y": 427.07293701171875
+                            "worldAABB_min_x": 721.7874145507813,
+                            "worldAABB_min_y": 360.8177185058594,
+                            "worldAABB_max_x": 731.7743530273438,
+                            "worldAABB_max_y": 384.7864685058594
                         }
                     },
                     {
@@ -10090,7 +10158,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 1.0,
@@ -10111,7 +10179,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.0
+                            "rbPos_Z": -14.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -10176,10 +10250,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": -6.667972564697266,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 83.12368774414063
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": -1.1523704528808594,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 78.74346923828125
                         }
                     },
                     {
@@ -10234,10 +10308,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": -6.667972564697266,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 83.12368774414063
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": -1.1523704528808594,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 78.74346923828125
                         }
                     },
                     {
@@ -10286,10 +10360,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 674.4247436523438,
-                            "worldAABB_min_y": 27.003902435302734,
-                            "worldAABB_max_x": 854.0081176757813,
-                            "worldAABB_max_y": 49.45181655883789
+                            "worldAABB_min_x": 600.0972290039063,
+                            "worldAABB_min_y": 28.80856704711914,
+                            "worldAABB_max_x": 759.8888549804688,
+                            "worldAABB_max_y": 48.782527923583984
                         }
                     },
                     {
@@ -10339,10 +10413,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 674.4247436523438,
-                            "worldAABB_min_y": 27.003902435302734,
-                            "worldAABB_max_x": 854.0081176757813,
-                            "worldAABB_max_y": 49.45181655883789
+                            "worldAABB_min_x": 600.0972290039063,
+                            "worldAABB_min_y": 28.80856704711914,
+                            "worldAABB_max_x": 759.8888549804688,
+                            "worldAABB_max_y": 48.782527923583984
                         }
                     },
                     {
@@ -10392,10 +10466,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 719.3206176757813,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 809.1122436523438,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 640.0451049804688,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 719.9409790039063,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -10430,10 +10504,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 777.1239624023438,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 866.9155883789063,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 691.4780883789063,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 771.3739624023438,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -10468,10 +10542,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 808.551025390625,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 835.488525390625,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 719.441650390625,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 743.410400390625,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -10521,10 +10595,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 721.1163940429688,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 810.9080200195313,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 641.6430053710938,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 721.5388793945313,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -10559,10 +10633,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 752.54345703125,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 779.48095703125,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 669.6065673828125,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 693.5753173828125,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -10612,10 +10686,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 664.9966430664063,
-                            "worldAABB_min_y": 37.7115592956543,
-                            "worldAABB_max_x": 754.7882690429688,
-                            "worldAABB_max_y": 127.50321960449219
+                            "worldAABB_min_x": 591.7081298828125,
+                            "worldAABB_min_y": 38.33613967895508,
+                            "worldAABB_max_x": 671.60400390625,
+                            "worldAABB_max_y": 118.23197937011719
                         }
                     }
                 ]
@@ -10650,10 +10724,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 696.4237060546875,
-                            "worldAABB_min_y": 69.13864135742188,
-                            "worldAABB_max_x": 723.3612060546875,
-                            "worldAABB_max_y": 96.07614135742188
+                            "worldAABB_min_x": 619.6716918945313,
+                            "worldAABB_min_y": 66.2996826171875,
+                            "worldAABB_max_x": 643.6404418945313,
+                            "worldAABB_max_y": 90.2684326171875
                         }
                     },
                     {
@@ -10703,10 +10777,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 742.6664428710938,
-                            "worldAABB_min_y": 61.05739212036133,
-                            "worldAABB_max_x": 785.7664184570313,
-                            "worldAABB_max_y": 104.15739440917969
+                            "worldAABB_min_x": 660.8180541992188,
+                            "worldAABB_min_y": 59.10905456542969,
+                            "worldAABB_max_x": 699.1680297851563,
+                            "worldAABB_max_y": 97.45906066894531
                         }
                     },
                     {
@@ -10756,10 +10830,10 @@
                             "localAABB_min_y": -0.5,
                             "localAABB_max_x": 0.5,
                             "localAABB_max_y": 0.5,
-                            "worldAABB_min_x": 742.6664428710938,
-                            "worldAABB_min_y": 61.05739212036133,
-                            "worldAABB_max_x": 785.7664184570313,
-                            "worldAABB_max_y": 104.15739440917969
+                            "worldAABB_min_x": 660.8180541992188,
+                            "worldAABB_min_y": 59.10905456542969,
+                            "worldAABB_max_x": 699.1680297851563,
+                            "worldAABB_max_y": 97.45906066894531
                         }
                     },
                     {
@@ -10810,7 +10884,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -10831,7 +10905,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": -13.659497261047363
+                            "rbPos_Z": -13.659497261047363,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -10936,7 +11016,13 @@
                             "height": 0.10000000149011612,
                             "rbPos_X": 0.024301884695887566,
                             "rbPos_Y": 0.45000001788139343,
-                            "rbPos_Z": -13.65949535369873
+                            "rbPos_Z": -13.65949535369873,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -11064,7 +11150,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0003662109375,
                             "rbPos_Y": 0.7203463315963745,
-                            "rbPos_Z": -13.513319969177246
+                            "rbPos_Z": -13.513319969177246,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -11203,7 +11295,13 @@
                             "height": 2.0,
                             "rbPos_X": 0.0,
                             "rbPos_Y": 0.0,
-                            "rbPos_Z": -14.25
+                            "rbPos_Z": -14.25,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {

--- a/Game/Assets/Scenes/NewDronePrefab.axolotl
+++ b/Game/Assets/Scenes/NewDronePrefab.axolotl
@@ -268,7 +268,13 @@
                             "height": 2.0,
                             "rbPos_X": -1.634626585200749e-7,
                             "rbPos_Y": 1.5,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {
@@ -2991,7 +2997,13 @@
                             "height": 2.0,
                             "rbPos_X": -6.501678626591456e-7,
                             "rbPos_Y": 1.0355559587478638,
-                            "rbPos_Z": 1.8622512817382813
+                            "rbPos_Z": 1.8622512817382813,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     }
                 ]
@@ -3027,7 +3039,7 @@
                             "type": "Component_RigidBody",
                             "active": true,
                             "removed": true,
-                            "isKinematic": false,
+                            "isKinematic": true,
                             "isTrigger": true,
                             "drawCollider": true,
                             "mass": 100.0,
@@ -3048,7 +3060,13 @@
                             "height": 2.0,
                             "rbPos_X": -5.654783308273181e-9,
                             "rbPos_Y": 1.2486436367034912,
-                            "rbPos_Z": 0.0
+                            "rbPos_Z": 0.0,
+                            "xAxisBlocked": false,
+                            "yAxisBlocked": false,
+                            "zAxisBlocked": false,
+                            "xRotationAxisBlocked": false,
+                            "yRotationAxisBlocked": false,
+                            "zRotationAxisBlocked": false
                         }
                     },
                     {

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -37,17 +37,12 @@ void EntityDetection::Start()
 	playerTransform = player->GetComponent<ComponentTransform>();
 
 	input = App->GetModule<ModuleInput>();
-
-	rigidBody->SetKpForce(50);
-}
-
-void EntityDetection::Update(float deltaTime)
-{
-	rigidBody->SetPositionTarget(playerTransform->GetGlobalPosition());
 }
 
 void EntityDetection::UpdateEnemyDetection(float distanceFilter)
 {
+	rigidBody->UpdateRigidBody();
+
 	vecForward = playerTransform->GetGlobalForward();
 	originPosition = playerTransform->GetGlobalPosition() - vecForward.Normalized() * interactionOffset;
 

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -18,7 +18,6 @@ public:
 	~EntityDetection() override = default;
 
 	void Start() override;
-	void Update(float deltaTime) override;
 
 	void UpdateEnemyDetection(float distanceFilter = 0.0f);
 

--- a/Game/Scripts/JumpFinisherArea.cpp
+++ b/Game/Scripts/JumpFinisherArea.cpp
@@ -39,7 +39,7 @@ void JumpFinisherArea::Start()
 
 void JumpFinisherArea::Update(float deltaTime)
 {
-	rigidBody->SetPositionTarget(parentTransform->GetGlobalPosition());
+	rigidBody->UpdateRigidBody();
 
 	if (!triggerParticleSystemTimer)
 	{

--- a/Game/Scripts/MeleeHeavyAttackBehaviourScript.cpp
+++ b/Game/Scripts/MeleeHeavyAttackBehaviourScript.cpp
@@ -32,7 +32,7 @@ void MeleeHeavyAttackBehaviourScript::Start()
 
 void MeleeHeavyAttackBehaviourScript::Update(float deltaTime)
 {
-	rigidBody->SetPositionTarget(parentTransform->GetGlobalPosition());
+	rigidBody->UpdateRigidBody();
 
 	if (attackState == ExplosionState::WAITING_EXPLOSION)
 	{


### PR DESCRIPTION
--Affected objects--
From Bix:
- `Bix Force Area`
- `Allura Force Area`
- `EnemyDetection`

From the drones:
- `ExplosionArea`

These objects' rigidbodies were set to kinematic and they changed from `rigidBody->SetPositionTarget()` to `rigidBody->UpdateRigidbody()` to update their movement at the same time the parent (Bix) moves. It was stated in today's meeting that this is the preferred way to move objects along with their parents.

Also, the scenes that had those objects (the newest Bix prefab or the newest drone prefab) were updated to match this change. 