### PR TITLE
feat: add an AXO_TODO macro so TODO comments don't just get forgotten

### DIFF
--- a/Source/DataModels/Components/ComponentPlayer.cpp
+++ b/Source/DataModels/Components/ComponentPlayer.cpp
@@ -7,6 +7,8 @@
 
 #include "FileSystem/Json.h"
 
+AXO_TODO("Remove this component")
+
 ComponentPlayer::ComponentPlayer(bool active, GameObject* owner) : Component(ComponentType::PLAYER, active, owner, true)
 {
 }

--- a/Source/DataModels/Components/ComponentPlayer.h
+++ b/Source/DataModels/Components/ComponentPlayer.h
@@ -1,8 +1,6 @@
 #pragma once
 #include "Component.h"
 
-#pragma message(__FILE__ " TODO: Remove this component")
-
 class ComponentPlayer : public Component
 {
 public:

--- a/Source/DataModels/Components/ComponentRigidBody.cpp
+++ b/Source/DataModels/Components/ComponentRigidBody.cpp
@@ -8,7 +8,6 @@
 #include "Geometry/Sphere.h"
 #include "ModulePhysics.h"
 #include "debugdraw.h"
-#include <ImGui/imgui.h>
 
 #include "ComponentScript.h"
 
@@ -105,7 +104,7 @@ void ComponentRigidBody::OnCollisionEnter(ComponentRigidBody* other)
 
 void ComponentRigidBody::OnCollisionStay(ComponentRigidBody* other)
 {
-	// TODO: Implement delegate for this
+	AXO_TODO("Implement delegate for this")
 	assert(other);
 }
 

--- a/Source/DataModels/GameObject/GameObject.cpp
+++ b/Source/DataModels/GameObject/GameObject.cpp
@@ -154,7 +154,8 @@ void GameObject::Load(const Json& meta)
 		if (type == ComponentType::LIGHT)
 		{
 			LightType lightType = GetLightTypeByName(jsonComponent["lightType"]);
-			CreateComponentLight(lightType, AreaType::NONE); // TODO look at this when implement metas
+			AXO_TODO("look at this when implement metas")
+			CreateComponentLight(lightType, AreaType::NONE);
 		}
 		else if (type == ComponentType::SCRIPT)
 		{

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -97,7 +97,7 @@ void Scene::FillQuadtree(const std::vector<GameObject*>& gameObjects)
 
 bool Scene::IsInsideACamera(const OBB& obb) const
 {
-	// TODO: We have to add all the cameras in the future
+	AXO_TODO("We have to add all the cameras in the future")
 	for (ComponentCamera* camera : sceneCameras)
 	{
 		if (camera->GetCamera()->IsInside(obb))

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAreaLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAreaLight.cpp
@@ -27,7 +27,7 @@ void WindowComponentAreaLight::DrawWindowContents()
 
 	if (asAreaLight)
 	{
-		AXO_TODO("ADD the rest of types once there are implemented");
+		AXO_TODO("ADD the rest of types once they are implemented");
 		const char* lightTypes[] = { "SPHERE", "TUBE" };
 
 		const char* currentType;

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAreaLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAreaLight.cpp
@@ -27,7 +27,8 @@ void WindowComponentAreaLight::DrawWindowContents()
 
 	if (asAreaLight)
 	{
-		const char* lightTypes[] = { "SPHERE", "TUBE" }; //TODO ADD the rest of types once there are implemented
+		AXO_TODO("ADD the rest of types once there are implemented");
+		const char* lightTypes[] = { "SPHERE", "TUBE" };
 
 		const char* currentType;
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -112,7 +112,7 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 			if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("GENERAL"))
 			{
 				UID draggedMeshUID = *(UID*) payload->Data; // Double pointer to keep track correctly
-				// TODO this should be Asset Path of the asset not the UID (Because new filesystem cache)
+				AXO_TODO("this should be Asset Path of the asset not the UID (Because new filesystem cache)")
 				std::shared_ptr<ResourceMesh> newMesh =
 					App->GetModule<ModuleResources>()->SearchResource<ResourceMesh>(draggedMeshUID);
 				// And then this should be RequestResource not SearchResource

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentParticle.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentParticle.cpp
@@ -642,7 +642,7 @@ void WindowComponentParticle::DrawEmitter(EmitterInstance* instance)
 			ImGui::EndTable();
 		}
 
-		//TODO: Draw Emitter Modules
+		AXO_TODO("Draw Emitter Modules")
 		for (ParticleModule* module : emitter->GetModules())
 		{
 			module->DrawImGui();
@@ -650,6 +650,6 @@ void WindowComponentParticle::DrawEmitter(EmitterInstance* instance)
 	}
 	else
 	{
-		//TODO: Select a ParticleEmitter to assign to the EmitterInstance (it acts as a Resource for the instance)
+		AXO_TODO("Select a ParticleEmitter to assign to the EmitterInstance (it acts as a Resource for the instance)")
 	}
 }

--- a/Source/DataModels/Windows/SubWindows/WindowFrustum.cpp
+++ b/Source/DataModels/Windows/SubWindows/WindowFrustum.cpp
@@ -58,7 +58,7 @@ void WindowFrustum::DrawWindowContents()
 	if (ImGui::SliderInt("Quadrant capacity", &quadrantCapacity, 1, 100, "%d", ImGuiSliderFlags_AlwaysClamp))
 	{
 		rootQuadtree->SetQuadrantCapacity(quadrantCapacity);
-		// TODO save values for future executions
+		AXO_TODO("save values for future executions")
 	}
 
 	float minQuadrantSideSize = rootQuadtree->GetMinQuadrantSideSize();
@@ -66,6 +66,6 @@ void WindowFrustum::DrawWindowContents()
 			"Minimum quadrant side size", &minQuadrantSideSize, 50.0, 500.0, "%.0f", ImGuiSliderFlags_AlwaysClamp))
 	{
 		rootQuadtree->SetMinQuadrantSideSize(minQuadrantSideSize);
-		// TODO save values for future executions
+		AXO_TODO("save values for future executions")
 	}
 }

--- a/Source/Defines/AxoTodo.h
+++ b/Source/Defines/AxoTodo.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define _STR(x) #x
+#define STR(x) _STR(x)
+
+#define AXO_TODO(todoMessage) __pragma(message(__FILE__ "("STR(__LINE__)") : TODO: " todoMessage))

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -884,6 +884,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseGame|x64'">true</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="Defines\ApplicationDefines.h" />
+    <ClInclude Include="Defines\AxoTodo.h" />
     <ClInclude Include="Defines\FrustumDefines.h" />
     <ClInclude Include="Defines\ExtensionDefines.h" />
     <ClInclude Include="Defines\FileSystemDefines.h" />

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -1310,6 +1310,7 @@
     <ClInclude Include="..\Game\Scripts\HeavyFinisherAttack.h">
       <Filter>UserScripts\Gameplay\Player\Attack\Finishers\Heavy Finisher</Filter>
     </ClInclude>
+    <ClInclude Include="Defines\AxoTodo.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Auxiliar">

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -169,7 +169,9 @@ std::shared_ptr<Resource> ModuleResources::CreateResourceOfType(UID uid,
 				new EditorResource<ResourceMesh>(uid, fileName, assetsPath, libraryPath),
 				CollectionAwareDeleter<Resource>());
 			break;
-		case ResourceType::Scene: // TODO
+		case ResourceType::Scene:
+			// good luck with that :)
+			AXO_TODO("Implement resource scene")
 			return nullptr;
 		case ResourceType::Material:
 			res = std::shared_ptr<EditorResource<ResourceMaterial>>(
@@ -238,7 +240,8 @@ std::shared_ptr<Resource> ModuleResources::CreateResourceOfType(UID uid,
 			return std::shared_ptr<ResourceMesh>(new ResourceMesh(uid, fileName, assetsPath, libraryPath),
 												 customDeleter);
 			break;
-		case ResourceType::Scene: // TODO
+		case ResourceType::Scene:
+			AXO_TODO("Implement resource scene")
 			return nullptr;
 		case ResourceType::Material:
 			return std::shared_ptr<ResourceMaterial>(new ResourceMaterial(uid, fileName, assetsPath, libraryPath),

--- a/Source/StdAfx.h
+++ b/Source/StdAfx.h
@@ -29,4 +29,5 @@
 
 #include "SDL.h"
 
+#include "Defines/AxoTodo.h"
 #include "AxoLog.h"


### PR DESCRIPTION
Noticed a bunch of ancient TODO comments that have probably been forgotten. Using this macro, this comments will appear in the compilation output, which will hopefully force to either address them or realize that they are done.