### PR TITLE
feat: Debug Camera Frustum utilities

### DIFF
--- a/Source/DataModels/Camera/CameraGameObject.cpp
+++ b/Source/DataModels/Camera/CameraGameObject.cpp
@@ -24,8 +24,6 @@ bool CameraGameObject::Init()
 	Camera::Init();
 	SetKpPosition(5.0f);
 	SetKpRotation(5.0f);
-	KpPosition = 5.0f;
-	KpRotation = 5.0f;
 	SetViewPlaneDistance(DEFAULT_GAMEOBJECT_FRUSTUM_DISTANCE);
 
 	return true;

--- a/Source/DataModels/Camera/CameraGameObject.cpp
+++ b/Source/DataModels/Camera/CameraGameObject.cpp
@@ -19,6 +19,18 @@ CameraGameObject::~CameraGameObject()
 {
 }
 
+bool CameraGameObject::Init()
+{
+	Camera::Init();
+	SetKpPosition(5.0f);
+	SetKpRotation(5.0f);
+	KpPosition = 5.0f;
+	KpRotation = 5.0f;
+	SetViewPlaneDistance(DEFAULT_GAMEOBJECT_FRUSTUM_DISTANCE);
+
+	return true;
+}
+
 bool CameraGameObject::Update()
 {
 	projectionMatrix = frustum->ProjectionMatrix();

--- a/Source/DataModels/Camera/CameraGameObject.h
+++ b/Source/DataModels/Camera/CameraGameObject.h
@@ -8,6 +8,7 @@ public:
 	CameraGameObject(const std::unique_ptr<Camera>& camera);
 	virtual ~CameraGameObject() override;
 
+	bool Init() override;
 	bool Update() override;
 
 	void SetPositionTarget(const float3& targetPosition, float deltaTime);

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -23,12 +23,12 @@ ComponentCamera::ComponentCamera(bool active, GameObject* owner) :
 {
 	camera = std::make_unique<CameraGameObject>();
 	camera->Init();
-	camera->SetKpPosition(5.0f);
-	camera->SetKpRotation(5.0f);
-	KpPosition = 5.0f;
-	KpRotation = 5.0f;
+
+	ComponentTransform* trans = GetOwner()->GetComponentInternal<ComponentTransform>();
+	camera->SetPosition(trans->GetGlobalPosition());
+	camera->ApplyRotation(trans->GetGlobalRotation());
+
 	isFrustumChecked = false;
-	camera->SetViewPlaneDistance(DEFAULT_GAMEOBJECT_FRUSTUM_DISTANCE);
 	Update();
 }
 

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -27,6 +27,7 @@ ComponentCamera::ComponentCamera(bool active, GameObject* owner) :
 	camera->SetKpRotation(5.0f);
 	KpPosition = 5.0f;
 	KpRotation = 5.0f;
+	isFrustumChecked = false;
 	camera->SetViewPlaneDistance(DEFAULT_GAMEOBJECT_FRUSTUM_DISTANCE);
 	Update();
 }

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -70,12 +70,12 @@ void ComponentCamera::OnTransformChanged()
 		ComponentTransform* trans = GetOwner()->GetComponentInternal<ComponentTransform>();
 
 		camera->SetPosition(trans->GetGlobalPosition());
-		camera->SetOrientation(trans->GetGlobalRotation().ToEulerXYZ());
+		camera->ApplyRotation(trans->GetGlobalRotation());
 
-		/*if (camera->GetFrustumMode() == EFrustumMode::offsetFrustum)
+		if (camera->GetFrustumMode() == EFrustumMode::offsetFrustum)
 		{
 			camera->RecalculateOffsetPlanes();
-		}*/
+		}
 	}
 #endif
 }

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -62,6 +62,24 @@ void ComponentCamera::Draw() const
 #endif // ENGINE
 }
 
+void ComponentCamera::OnTransformChanged()
+{
+#ifdef ENGINE
+	if (!App->IsOnPlayMode())
+	{
+		ComponentTransform* trans = GetOwner()->GetComponentInternal<ComponentTransform>();
+
+		camera->SetPosition(trans->GetGlobalPosition());
+		camera->SetOrientation(trans->GetGlobalRotation().ToEulerXYZ());
+
+		/*if (camera->GetFrustumMode() == EFrustumMode::offsetFrustum)
+		{
+			camera->RecalculateOffsetPlanes();
+		}*/
+	}
+#endif
+}
+
 void ComponentCamera::SetSampleKpPosition(float kp)
 {
 	camera->SetKpPosition(kp);

--- a/Source/DataModels/Components/ComponentCamera.cpp
+++ b/Source/DataModels/Components/ComponentCamera.cpp
@@ -29,6 +29,9 @@ ComponentCamera::ComponentCamera(bool active, GameObject* owner) :
 	camera->ApplyRotation(trans->GetGlobalRotation());
 
 	isFrustumChecked = false;
+	KpPosition = camera->GetKpPosition();
+	KpRotation = camera->GetKpRotation();
+	camera->SetViewPlaneDistance(DEFAULT_GAMEOBJECT_FRUSTUM_DISTANCE);
 	Update();
 }
 

--- a/Source/DataModels/Components/ComponentCamera.h
+++ b/Source/DataModels/Components/ComponentCamera.h
@@ -29,6 +29,8 @@ public:
 	void Update() override;
 	void Draw() const override;
 
+	void OnTransformChanged() override;
+
 	CameraGameObject* GetCamera();
 
 	void DuplicateCamera(CameraGameObject* camera);

--- a/Source/DataModels/Components/ComponentCamera.h
+++ b/Source/DataModels/Components/ComponentCamera.h
@@ -41,10 +41,13 @@ public:
 	void RestoreKpPosition();
 	void RestoreKpRotation();
 
-	float GetKpPosition();
+	float GetKpPosition() const;
 	void SetKpPosition(float kp);
-	float GetKpRotation();
+	float GetKpRotation() const;
 	void SetKpRotation(float kp);
+
+	bool IsFrustumChecked() const;
+	void SetFrustumChecked(bool checked);
 
 private:
 	void InternalSave(Json& meta) override;
@@ -54,6 +57,8 @@ private:
 	std::unique_ptr<CameraGameObject> camera;
 	float KpPosition;
 	float KpRotation;
+
+	bool isFrustumChecked;
 };
 
 inline CameraGameObject* ComponentCamera::GetCamera()
@@ -61,7 +66,7 @@ inline CameraGameObject* ComponentCamera::GetCamera()
 	return camera.get();
 }
 
-inline float ComponentCamera::GetKpPosition()
+inline float ComponentCamera::GetKpPosition() const
 {
 	return KpPosition;
 }
@@ -71,7 +76,7 @@ inline void ComponentCamera::SetKpPosition(float kp)
 	KpPosition = kp;
 }
 
-inline float ComponentCamera::GetKpRotation()
+inline float ComponentCamera::GetKpRotation() const
 {
 	return KpRotation;
 }
@@ -79,4 +84,14 @@ inline float ComponentCamera::GetKpRotation()
 inline void ComponentCamera::SetKpRotation(float kp)
 {
 	KpRotation = kp;
+}
+
+inline bool ComponentCamera::IsFrustumChecked() const
+{
+	return isFrustumChecked;
+}
+
+inline void ComponentCamera::SetFrustumChecked(bool checked)
+{
+	isFrustumChecked = checked;
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
@@ -62,6 +62,11 @@ void WindowComponentCamera::DrawWindowContents()
 			ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
 			moduleCamera->SetFrustumCheckedCamera(asCamera);
 		}
+
+		else
+		{
+			asCamera->SetFrustumChecked(false);
+		}
 		
 
 		asCamera->SetKpPosition(kpPosition);

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
@@ -35,6 +35,29 @@ void WindowComponentCamera::DrawWindowContents()
 		float kpPosition = asCamera->GetKpPosition();
 		float kpRotation = asCamera->GetKpRotation();
 
+		float hFov = asCamera->GetCamera()->GetHFOV();
+		if (ImGui::SliderFloat("Horizontal FOV", &hFov, MIN_HFOV, MAX_HFOV, "%.0f", ImGuiSliderFlags_AlwaysClamp))
+		{
+			asCamera->GetCamera()->SetHFOV(math::DegToRad(hFov));
+		}
+
+		float vFov = asCamera->GetCamera()->GetVFOV();
+		if (ImGui::SliderFloat("Vertical FOV", &vFov, MIN_VFOV, MAX_VFOV, "%.0f", ImGuiSliderFlags_AlwaysClamp))
+		{
+			asCamera->GetCamera()->SetVFOV(math::DegToRad(vFov));
+		}
+
+		float nearDistance = asCamera->GetCamera()->GetZNear();
+		float farDistance = asCamera->GetCamera()->GetZFar();
+		bool nearDistanceChanged =
+			ImGui::SliderFloat("Z near", &nearDistance, 0.1f, 200.f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+		bool farDistanceChanged =
+			ImGui::SliderFloat("Z far", &farDistance, 500.f, 20000.f, "%0.f", ImGuiSliderFlags_AlwaysClamp);
+		if (nearDistanceChanged || farDistanceChanged)
+		{
+			asCamera->GetCamera()->SetPlaneDistance(nearDistance, farDistance);
+		}
+
 		bool isFrustumChecked = asCamera->IsFrustumChecked();
 
 		ImGui::Text("Draw Frustum");

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
@@ -2,6 +2,9 @@
 
 #include "WindowComponentCamera.h"
 
+#include "Application.h"
+#include "Modules/ModuleCamera.h"
+
 #include "Camera/CameraGameObject.h"
 #include "DataModels/Components/ComponentCamera.h"
 
@@ -32,9 +35,15 @@ void WindowComponentCamera::DrawWindowContents()
 		float kpPosition = asCamera->GetKpPosition();
 		float kpRotation = asCamera->GetKpRotation();
 
+		bool isFrustumChecked = asCamera->IsFrustumChecked();
+
 		ImGui::Text("Draw Frustum");
 		ImGui::SameLine();
 		ImGui::Checkbox("##Draw Frustum", &drawFrustum);
+
+		ImGui::Text("Use this Frustum");
+		ImGui::SameLine();
+		ImGui::Checkbox("##Use this Frustum", &isFrustumChecked);
 
 		ImGui::ListBox(
 			"Frustum Mode\n(single select)", &frustumModeAsNumber, listbox_items, IM_ARRAYSIZE(listbox_items), 3);
@@ -47,6 +56,13 @@ void WindowComponentCamera::DrawWindowContents()
 		EFrustumMode newFrustumMode = static_cast<EFrustumMode>(frustumModeAsNumber);
 		asCamera->GetCamera()->SetFrustumMode(newFrustumMode);
 		asCamera->GetCamera()->SetFrustumOffset(frustumOffset);
+
+		if (isFrustumChecked)
+		{
+			ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
+			moduleCamera->SetFrustumCheckedCamera(asCamera);
+		}
+		
 
 		asCamera->SetKpPosition(kpPosition);
 		asCamera->SetKpRotation(kpRotation);

--- a/Source/Modules/ModuleCamera.cpp
+++ b/Source/Modules/ModuleCamera.cpp
@@ -176,6 +176,7 @@ void ModuleCamera::SetSelectedCamera(int cameraNumber)
 	}
 }
 
+
 Camera* ModuleCamera::GetFrustumCheckedCamera() const
 {
 	std::vector<ComponentCamera*> loadedCameras = App->GetModule<ModuleScene>()->GetLoadedScene()->GetSceneCameras();
@@ -186,9 +187,11 @@ Camera* ModuleCamera::GetFrustumCheckedCamera() const
 			return camera->GetCamera();
 		}
 	}
+
+	return nullptr;
 }
 
-void SetFrustumCheckedCamera(ComponentCamera* camera)
+void ModuleCamera::SetFrustumCheckedCamera(ComponentCamera* camera)
 {
 	std::vector<ComponentCamera*> loadedCameras = App->GetModule<ModuleScene>()->GetLoadedScene()->GetSceneCameras();
 

--- a/Source/Modules/ModuleCamera.cpp
+++ b/Source/Modules/ModuleCamera.cpp
@@ -43,6 +43,7 @@ bool ModuleCamera::Start()
 	}
 #ifdef ENGINE
 	selectedCamera = camera.get();
+	frustumCheckedCamera = selectedCamera;
 #else  // ENGINE
 	// selectedPosition = 1;
 	// SetSelectedCamera(selectedPosition);
@@ -174,6 +175,36 @@ void ModuleCamera::SetSelectedCamera(int cameraNumber)
 		}
 	}
 }
+
+Camera* ModuleCamera::GetFrustumCheckedCamera() const
+{
+	std::vector<ComponentCamera*> loadedCameras = App->GetModule<ModuleScene>()->GetLoadedScene()->GetSceneCameras();
+	for (auto camera: loadedCameras)
+	{
+		if (camera->IsFrustumChecked())
+		{
+			return camera->GetCamera();
+		}
+	}
+}
+
+void SetFrustumCheckedCamera(ComponentCamera* camera)
+{
+	std::vector<ComponentCamera*> loadedCameras = App->GetModule<ModuleScene>()->GetLoadedScene()->GetSceneCameras();
+
+	for (ComponentCamera* loadedCamera : loadedCameras)
+	{
+		if (loadedCamera != camera)
+		{
+			loadedCamera->SetFrustumChecked(false);
+		}
+		else
+		{
+			loadedCamera->SetFrustumChecked(true);
+		}
+	}
+}
+
 
 void ModuleCamera::RecalculateOrthoProjectionMatrix()
 {

--- a/Source/Modules/ModuleCamera.cpp
+++ b/Source/Modules/ModuleCamera.cpp
@@ -177,14 +177,14 @@ void ModuleCamera::SetSelectedCamera(int cameraNumber)
 }
 
 
-Camera* ModuleCamera::GetFrustumCheckedCamera() const
+ComponentCamera* ModuleCamera::GetFrustumCheckedCamera() const
 {
 	std::vector<ComponentCamera*> loadedCameras = App->GetModule<ModuleScene>()->GetLoadedScene()->GetSceneCameras();
 	for (auto camera: loadedCameras)
 	{
 		if (camera->IsFrustumChecked())
 		{
-			return camera->GetCamera();
+			return camera;
 		}
 	}
 

--- a/Source/Modules/ModuleCamera.h
+++ b/Source/Modules/ModuleCamera.h
@@ -36,7 +36,7 @@ public:
 	Camera* GetCamera();
 	void ChangeCamera(CameraType newType);
 	Camera* GetSelectedCamera() const;
-	Camera* GetFrustumCheckedCamera() const;
+	ComponentCamera* GetFrustumCheckedCamera() const;
 	void SetSelectedCamera(int cameraNumber);
 	void SetFrustumCheckedCamera(ComponentCamera* camera);
 	int GetSelectedPosition();

--- a/Source/Modules/ModuleCamera.h
+++ b/Source/Modules/ModuleCamera.h
@@ -17,6 +17,7 @@
 
 class GameObject;
 class WindowScene;
+class ComponentCamera;
 class Camera;
 
 enum class CameraType;
@@ -35,7 +36,9 @@ public:
 	Camera* GetCamera();
 	void ChangeCamera(CameraType newType);
 	Camera* GetSelectedCamera() const;
+	Camera* GetFrustumCheckedCamera() const;
 	void SetSelectedCamera(int cameraNumber);
+	void SetFrustumCheckedCamera(ComponentCamera* camera);
 	int GetSelectedPosition();
 	void SetSelectedPosition(int newSelected);
 
@@ -45,6 +48,7 @@ public:
 private:
 	std::unique_ptr<Camera> camera;
 	Camera* selectedCamera;
+	Camera* frustumCheckedCamera;
 	int selectedPosition;
 
 	float4x4 orthoProjectionMatrix;

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -532,8 +532,9 @@ void ModuleRender::FillRenderList(const Quadtree* quadtree)
 
 void ModuleRender::AddToRenderList(const GameObject* gameObject)
 {
-	ModuleCamera* camera = App->GetModule<ModuleCamera>();
-	float3 cameraPos = camera->GetCamera()->GetPosition();
+	ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
+	Camera* frustumCheckedCamera = moduleCamera->GetFrustumCheckedCamera();
+	float3 cameraPos = frustumCheckedCamera->GetPosition();
 
 	if (gameObject->GetParent() == nullptr)
 	{
@@ -547,7 +548,7 @@ void ModuleRender::AddToRenderList(const GameObject* gameObject)
 		return;
 	}
 
-	if (camera->GetCamera()->IsInside(transform->GetEncapsuledAABB()))
+	if (frustumCheckedCamera->IsInside(transform->GetEncapsuledAABB()))
 	{
 		ComponentMeshRenderer* mesh = gameObject->GetComponentInternal<ComponentMeshRenderer>();
 		if (gameObject->IsActive() && (mesh == nullptr || mesh->IsEnabled()))

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -493,18 +493,7 @@ void ModuleRender::FillRenderList(const Quadtree* quadtree)
 		return;
 	}
 
-	ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
-	ComponentCamera* frustumCheckedCamera = moduleCamera->GetFrustumCheckedCamera();
-	Camera* camera;
-	if (!frustumCheckedCamera)
-	{
-		camera = moduleCamera->GetCamera();
-	}
-	else
-	{
-		camera = (Camera*)frustumCheckedCamera->GetCamera();
-	}
-
+	Camera* camera = GetFrustumCheckedCamera();
 		
 	float3 cameraPos = camera->GetPosition();
 
@@ -556,17 +545,8 @@ void ModuleRender::FillRenderList(const Quadtree* quadtree)
 
 void ModuleRender::AddToRenderList(const GameObject* gameObject)
 {
-	ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
-	ComponentCamera* frustumCheckedCamera = moduleCamera->GetFrustumCheckedCamera();
-	Camera* camera;
-	if (!frustumCheckedCamera)
-	{
-		camera = moduleCamera->GetCamera();
-	}
-	else
-	{
-		camera = (Camera*) frustumCheckedCamera->GetCamera();
-	}
+	
+	Camera* camera = GetFrustumCheckedCamera();
 
 	float3 cameraPos = camera->GetPosition();
 
@@ -689,6 +669,20 @@ void ModuleRender::BindCubemapToProgram(Program* program)
 	program->BindUniformFloat("cubemap_intensity", cubemap->GetIntensity());
 
 	program->Deactivate();
+}
+
+Camera* ModuleRender::GetFrustumCheckedCamera() const
+{
+	ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
+	ComponentCamera* frustumCheckedCamera = moduleCamera->GetFrustumCheckedCamera();
+	if (!frustumCheckedCamera)
+	{
+		return moduleCamera->GetCamera();
+	}
+	else
+	{
+		return (Camera*) frustumCheckedCamera->GetCamera();
+	}
 }
 
 bool ModuleRender::CheckIfTransparent(const GameObject* gameObject)

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -534,6 +534,10 @@ void ModuleRender::AddToRenderList(const GameObject* gameObject)
 {
 	ModuleCamera* moduleCamera = App->GetModule<ModuleCamera>();
 	Camera* frustumCheckedCamera = moduleCamera->GetFrustumCheckedCamera();
+	if (!frustumCheckedCamera)
+	{
+		frustumCheckedCamera = moduleCamera->GetCamera();
+	}
 	float3 cameraPos = frustumCheckedCamera->GetPosition();
 
 	if (gameObject->GetParent() == nullptr)

--- a/Source/Modules/ModuleRender.h
+++ b/Source/Modules/ModuleRender.h
@@ -15,6 +15,7 @@ class Quadtree;
 class Program;
 class Cubemap;
 class GameObject;
+class Camera;
 class GeometryBatch;
 class BatchManager;
 class ComponentMeshRenderer;
@@ -72,6 +73,8 @@ private:
 
 	void BindCameraToProgram(Program* program);
 	void BindCubemapToProgram(Program* program);
+
+	Camera* GetFrustumCheckedCamera() const;
 
 	void* context;
 


### PR DESCRIPTION
- Fixed the Frustum position and orientation. Now you can move scene Camera objects and Frustum gets updated.
- You can select the frustum to use and cull the objects outside it.
- The frustum selected to use is also drawn if you check it.
- Only one frustum can be selected. If none of them are checked, the Engine Camera frustum will be the one selected.