### PR TITLE
fix: scene importing works again

### DIFF
--- a/Source/Auxiliar/SceneLoader.cpp
+++ b/Source/Auxiliar/SceneLoader.cpp
@@ -81,7 +81,7 @@ void OnLoadedScene()
 	{
 		player->LoadNewPlayer();
 	}
-	
+
 	ModuleScene* scene = App->GetModule<ModuleScene>();
 	scene->InitAndStartScriptingComponents();
 	scene->InitParticlesComponents();
@@ -476,6 +476,17 @@ void LoadScene(std::variant<std::string, std::reference_wrapper<rapidjson::Docum
 bool IsLoading()
 {
 	return currentLoadingConfig.has_value();
+}
+
+bool HasNewUID(UID oldUID, UID& newUID)
+{
+	const auto& uid = uidMap.find(oldUID);
+	if (uid == uidMap.end())
+	{
+		return false;
+	}
+	newUID = uid->second;
+	return true;
 }
 
 } // namespace loader

--- a/Source/Auxiliar/SceneLoader.h
+++ b/Source/Auxiliar/SceneLoader.h
@@ -2,6 +2,8 @@
 
 #include "rapidjson/document.h"
 
+#include "FileSystem/UID.h"
+
 namespace loader
 {
 enum class LoadMode
@@ -16,4 +18,6 @@ void LoadScene(std::variant<std::string, std::reference_wrapper<rapidjson::Docum
 			   LoadMode loadMode);
 
 bool IsLoading();
+
+bool HasNewUID(UID oldUID, UID& newUID);
 } // namespace loader

--- a/Source/DataModels/Components/ComponentScript.cpp
+++ b/Source/DataModels/Components/ComponentScript.cpp
@@ -514,7 +514,7 @@ void ComponentScript::InternalLoad(const Json& meta)
 					if (fieldUID != 0)
 					{
 						UID newFieldUID;
-						if (App->GetModule<ModuleScene>()->hasNewUID(fieldUID, newFieldUID))
+						if (App->GetModule<ModuleScene>()->HasNewUID(fieldUID, newFieldUID))
 						{
 							optField.value().setter(
 								App->GetModule<ModuleScene>()->GetLoadedScene()->SearchGameObjectByID(newFieldUID));
@@ -615,7 +615,7 @@ void ComponentScript::InternalLoad(const Json& meta)
 							if (fieldUID != 0)
 							{
 								UID newFieldUID;
-								if (App->GetModule<ModuleScene>()->hasNewUID(fieldUID, newFieldUID))
+								if (App->GetModule<ModuleScene>()->HasNewUID(fieldUID, newFieldUID))
 								{
 									vectorCase.push_back((GameObject*) App->GetModule<ModuleScene>()
 															 ->GetLoadedScene()

--- a/Source/DataModels/Components/UI/ComponentSlider.cpp
+++ b/Source/DataModels/Components/UI/ComponentSlider.cpp
@@ -245,7 +245,7 @@ GameObject* ComponentSlider::LoadGameObject(const Json& meta, const char* name)
 	if (uid != 0)
 	{
 		UID newUID;
-		if (App->GetModule<ModuleScene>()->hasNewUID(uid, newUID))
+		if (App->GetModule<ModuleScene>()->HasNewUID(uid, newUID))
 		{
 			return App->GetModule<ModuleScene>()->GetLoadedScene()->SearchGameObjectByID(newUID);
 		}

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -433,16 +433,7 @@ void ModuleScene::RemoveGameObject(const GameObject* object)
 	}
 }
 
-bool ModuleScene::hasNewUID(UID oldUID, UID& newUID)
+bool ModuleScene::HasNewUID(UID oldUID, UID& newUID)
 {
-	const auto& uid = uidMap.find(oldUID);
-	if (uid == uidMap.end())
-	{
-		return false;
-	}
-	else
-	{
-		newUID = uid->second;
-		return true;
-	}
+	return loader::HasNewUID(oldUID, newUID);
 }

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -30,7 +30,7 @@ public:
 	GameObject* GetSelectedGameObject() const;
 	void SetSelectedGameObject(GameObject* gameObject);
 	void SetSceneToLoad(const std::string& name);
-	bool hasNewUID(UID oldUID, UID& newUID);
+	bool HasNewUID(UID oldUID, UID& newUID);
 	void SetSceneRootAnimObjects(std::vector<GameObject*> gameObjects);
 
 	void SaveScene(const std::string& name);
@@ -67,7 +67,6 @@ private:
 
 	// to store the tmp serialization of the Scene
 	rapidjson::Document tmpDoc;
-	std::map<UID, UID> uidMap;
 
 	std::mutex loadedSceneMutex;
 };


### PR DESCRIPTION
`ModuleScene::HasNewUID` wasn't updated with the changes to how we load scenes, which resulted in us checking a map that was always empty. Moved that functionality to a helper function inside `SceneLoader`.