### PR TITLE
fix: add more protection when scene is loading

### DIFF
--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -185,6 +185,11 @@ WindowInspector::~WindowInspector()
 
 void WindowInspector::DrawWindowContents()
 {
+	if (App->GetModule<ModuleScene>()->IsLoading())
+	{
+		return;
+	}
+
 	if (!resource.expired() && lastSelectedGameObject != App->GetModule<ModuleScene>()->GetSelectedGameObject())
 	{
 		resource = std::weak_ptr<Resource>();

--- a/Source/DataModels/Windows/EditorWindows/WindowScene.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowScene.cpp
@@ -45,7 +45,7 @@ void WindowScene::DrawWindowContents()
 				 ImVec2(0, 1),
 				 ImVec2(1, 0));
 
-	if (!App->IsOnPlayMode() || !App->GetModule<ModuleScene>()->IsLoading())
+	if (!App->IsOnPlayMode() && !App->GetModule<ModuleScene>()->IsLoading())
 	{
 		DrawGuizmo();
 	}

--- a/Source/Scheduler.cpp
+++ b/Source/Scheduler.cpp
@@ -14,6 +14,11 @@ Scheduler::~Scheduler()
 
 void Scheduler::ScheduleTask(Schedulable&& taskToSchedule)
 {
+	if (!taskToSchedule)
+	{
+		LOG_WARNING("Trying to schedule an empty task!");
+		return;
+	}
 	std::scoped_lock(schedulerMutex);
 	scheduledTasks.push(std::move(taskToSchedule));
 }


### PR DESCRIPTION
Try to prevent sensitive methods when the scene is loading.