### PR TITLE
fix: couple aspects of the jump attack

### DIFF
--- a/Game/Scripts/BixAttackScript.cpp
+++ b/Game/Scripts/BixAttackScript.cpp
@@ -197,7 +197,10 @@ void BixAttackScript::JumpNormalAttack()
 	jumpFinisherScript->PerformGroundSmash(10.0f, 2.0f); // Bix jumping attack
 	//jumpFinisherScript->ShootForceBullet(10.0f, 2.0f); // Allura jumping attack, placed it here for now
 
-	comboSystem->SuccessfulAttack(20.0f, currentAttack);
+	if (enemyDetection->AreAnyEnemiesInTheArea())
+	{
+		comboSystem->SuccessfulAttack(20.0f, currentAttack);
+	}
 }
 
 void BixAttackScript::LightFinisher()

--- a/Game/Scripts/EntityDetection.cpp
+++ b/Game/Scripts/EntityDetection.cpp
@@ -208,3 +208,8 @@ GameObject* EntityDetection::GetEnemySelected() const
 		return nullptr;
 	}
 }
+
+bool EntityDetection::AreAnyEnemiesInTheArea() const
+{
+	return !enemiesInTheArea.empty();
+}

--- a/Game/Scripts/EntityDetection.h
+++ b/Game/Scripts/EntityDetection.h
@@ -25,6 +25,7 @@ public:
 	virtual void OnCollisionExit(ComponentRigidBody* other) override;
 
 	GameObject* GetEnemySelected() const;
+	bool AreAnyEnemiesInTheArea() const;
 
 private:
 	void DrawDetectionLines(float distanceFilter);

--- a/Game/Scripts/JumpFinisherArea.cpp
+++ b/Game/Scripts/JumpFinisherArea.cpp
@@ -12,6 +12,8 @@
 
 #include "../Scripts/HealthSystem.h"
 #include "../Scripts/EnemyClass.h"
+#include "../Scripts/EnemyMiniBossTwo.h"
+#include "../Scripts/FinalBossScript.h"
 
 REGISTERCLASS(JumpFinisherArea);
 
@@ -91,6 +93,14 @@ void JumpFinisherArea::PushEnemies(float pushForce, float stunTime)
 	for (std::vector<GameObject*>::iterator it = enemiesInTheArea.begin(); it < enemiesInTheArea.end();
 		it++)
 	{
+		// If you think about a better way to identify the bosses lmk, tags are already in use
+		// and as there will only be three bosses, this is a "not so bad" approach I guess
+		AXO_TODO("Add here miniboss 1 script if finally developed, so no boss gets pushed back by this attack");
+		if ((*it)->HasComponent<EnemyMiniBossTwo>() || (*it)->HasComponent<FinalBossScript>())
+		{
+			continue;
+		}
+
 		const ComponentTransform* enemyTransform =
 			(*it)->GetComponent<ComponentTransform>();
 		ComponentRigidBody* enemyRigidBody =


### PR DESCRIPTION
What was fixed?
- Jump attack does not increase the combo bar if no enemies are hit.
- Jump attack does not push back the minibosses or the final boss (they are suposed to be heavier and sturdier).