### PR TITLE
fix: call SetContainer in copy constructor

### DIFF
--- a/Game/Scripts/RangedFastAttackBehaviourScript.cpp
+++ b/Game/Scripts/RangedFastAttackBehaviourScript.cpp
@@ -142,7 +142,6 @@ void RangedFastAttackBehaviourScript::ShootBullet()
 	script->SetScript(App->GetScriptFactory()->ConstructScript("RangedFastAttackBullet"));
 	script->SetConstuctor("RangedFastAttackBullet");
 	script->GetScript()->SetOwner(bullet);
-	script->GetScript()->SetContainer(script);
 
 	bullet->GetComponent<RangedFastAttackBullet>()->SetBulletVelocity(bulletVelocity);
 	bullet->GetComponent<RangedFastAttackBullet>()->SetBulletDamage(attackDamage);

--- a/Source/DataModels/Components/ComponentScript.cpp
+++ b/Source/DataModels/Components/ComponentScript.cpp
@@ -107,6 +107,8 @@ ComponentScript::ComponentScript(const ComponentScript& other) :
 	{
 		return;
 	}
+
+	script->SetContainer(this);
 	for (const TypeFieldPair& typeFieldPair : script->GetFields())
 	{
 		switch (typeFieldPair.first)


### PR DESCRIPTION
Just realized I forgot to add that. Also remove unnecessary addition to scripts; SetContainer will be called together with SetScript, so no need for scripts to call it explicitly.