### PR TITLE
feat[SCM]: Cascade Shadow Maps

### DIFF
--- a/Game/Assets/Scenes/shadow_testing.axolotl
+++ b/Game/Assets/Scenes/shadow_testing.axolotl
@@ -1,0 +1,535 @@
+{
+    "GameObjects": [
+        {
+            "GameObject": {
+                "name": "shadow_testing",
+                "tag": "",
+                "uid": 758755892730740989,
+                "parentUID": 0,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 0.0,
+                            "localPos_Z": 0.0,
+                            "localRot_X": -0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": -0.0,
+                            "localSca_X": 1.0,
+                            "localSca_Y": 1.0,
+                            "localSca_Z": 1.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Skybox",
+                            "active": true,
+                            "removed": true,
+                            "Skybox": {
+                                "enable": true,
+                                "skyboxUID": 4377575066284441384,
+                                "skyboxAssetPath": "Assets/SkyBox/skybox.sky"
+                            }
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Render",
+                            "active": true,
+                            "removed": false,
+                            "bloom_intensity": 1.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Cubemap",
+                            "active": true,
+                            "removed": false,
+                            "intensity": 1.0
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Directional_Light",
+                "tag": "",
+                "uid": 118780766345130231,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 7.625,
+                            "localPos_Z": 0.0,
+                            "localRot_X": 126.94322204589844,
+                            "localRot_Y": -16.57082176208496,
+                            "localRot_Z": -20.769535064697266,
+                            "localSca_X": 1.0,
+                            "localSca_Y": 1.0,
+                            "localSca_Z": 1.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_Light",
+                            "active": true,
+                            "removed": false,
+                            "color_light_X": 1.0,
+                            "color_light_Y": 1.0,
+                            "color_light_Z": 1.0,
+                            "intensity": 1.0,
+                            "lightType": "LightType_Directional"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cube",
+                "tag": "",
+                "uid": 16341793334820643518,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 0.125,
+                            "localPos_Z": 0.0,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 42.25,
+                            "localSca_Y": 0.12529818713665009,
+                            "localSca_Z": 234.24256896972656,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 5838496268976162218,
+                            "assetPathMesh": "Assets/Meshes/Cube.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cube",
+                "tag": "",
+                "uid": 14004982176419714448,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 10.436601638793945,
+                            "localPos_Y": 28.523906707763672,
+                            "localPos_Z": -67.80658721923828,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 29.629409790039063,
+                            "localSca_Y": 28.086750030517578,
+                            "localSca_Z": 4.089238166809082,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 5838496268976162218,
+                            "assetPathMesh": "Assets/Meshes/Cube.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cube",
+                "tag": "",
+                "uid": 17384347335065072252,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": -28.266948699951172,
+                            "localPos_Y": 11.869939804077148,
+                            "localPos_Z": -11.167115211486816,
+                            "localRot_X": 92.3551025390625,
+                            "localRot_Y": 60.5173225402832,
+                            "localRot_Z": -92.70503997802734,
+                            "localSca_X": 2.2069003582000732,
+                            "localSca_Y": 11.630393028259277,
+                            "localSca_Z": 2.4631412029266357,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 5838496268976162218,
+                            "assetPathMesh": "Assets/Meshes/Cube.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Sphere",
+                "tag": "",
+                "uid": 12213577659816258803,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 4.755918502807617,
+                            "localPos_Y": 30.937742233276367,
+                            "localPos_Z": -23.658784866333008,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 3.0,
+                            "localSca_Y": 3.0,
+                            "localSca_Z": 3.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 6159512386276426707,
+                            "assetPathMesh": "Assets/Meshes/sphere.sphere_0.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Character",
+                "tag": "",
+                "uid": 16148146978682559796,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 0.0,
+                            "localPos_Y": 1.1549205780029297,
+                            "localPos_Z": 35.10255813598633,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 3.0,
+                            "localSca_Y": 3.0,
+                            "localSca_Z": 3.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 17111265744902053557,
+                            "assetPathMesh": "Assets/Meshes/David.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cylinder",
+                "tag": "",
+                "uid": 1215274478943675735,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": -19.633859634399414,
+                            "localPos_Y": 6.530893325805664,
+                            "localPos_Z": 35.467529296875,
+                            "localRot_X": 0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": 0.0,
+                            "localSca_X": 6.013604164123535,
+                            "localSca_Y": 6.02964448928833,
+                            "localSca_Z": 1.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 1852737626034071509,
+                            "assetPathMesh": "Assets/Meshes/Cylinder.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cylinder",
+                "tag": "",
+                "uid": 11556852817574748546,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 17.76262092590332,
+                            "localPos_Y": 6.530893325805664,
+                            "localPos_Z": 35.467529296875,
+                            "localRot_X": -0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": -0.0,
+                            "localSca_X": 6.013604164123535,
+                            "localSca_Y": 6.02964448928833,
+                            "localSca_Z": 1.0,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 1852737626034071509,
+                            "assetPathMesh": "Assets/Meshes/Cylinder.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cube",
+                "tag": "",
+                "uid": 137030316059050881,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": 29.49125862121582,
+                            "localPos_Y": 11.869939804077148,
+                            "localPos_Z": -10.776863098144531,
+                            "localRot_X": -0.0,
+                            "localRot_Y": 0.0,
+                            "localRot_Z": -0.0,
+                            "localSca_X": 2.2069003582000732,
+                            "localSca_Y": 11.63039493560791,
+                            "localSca_Z": 2.4631412029266357,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 5838496268976162218,
+                            "assetPathMesh": "Assets/Meshes/Cube.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "GameObject": {
+                "name": "Cube",
+                "tag": "",
+                "uid": 4381685902666103081,
+                "parentUID": 758755892730740989,
+                "enabled": true,
+                "static": false,
+                "Components": [
+                    {
+                        "Component": {
+                            "type": "Component_Transform",
+                            "active": true,
+                            "removed": false,
+                            "localPos_X": -12.477118492126465,
+                            "localPos_Y": 11.869939804077148,
+                            "localPos_Z": -11.514581680297852,
+                            "localRot_X": 85.9037094116211,
+                            "localRot_Y": -60.4619255065918,
+                            "localRot_Z": 85.29425048828125,
+                            "localSca_X": 2.2069003582000732,
+                            "localSca_Y": 11.630393981933594,
+                            "localSca_Z": 2.4631412029266357,
+                            "boudingBoxSca_X": 1.0,
+                            "boudingBoxSca_Y": 1.0,
+                            "boudingBoxSca_Z": 1.0,
+                            "boudingBoxPos_X": 0.0,
+                            "boudingBoxPos_Y": 0.0,
+                            "boudingBoxPos_Z": 0.0
+                        }
+                    },
+                    {
+                        "Component": {
+                            "type": "Component_MeshRenderer",
+                            "active": true,
+                            "removed": true,
+                            "meshUID": 5838496268976162218,
+                            "assetPathMesh": "Assets/Meshes/Cube.mesh",
+                            "materialUID": 4337559970860798462,
+                            "assetPathMaterial": "Assets/Materials/Default.mat"
+                        }
+                    }
+                ]
+            }
+        }
+    ],
+    "Quadtree": {
+        "BoundingBox": {
+            "MinPoint": {
+                "x": -25.0,
+                "y": -10.0,
+                "z": -25.0
+            },
+            "MaxPoint": {
+                "x": 25.0,
+                "y": 10.0,
+                "z": 25.0
+            }
+        }
+    },
+    "Cubemap": {
+        "cubemapUID": 992078593789236745,
+        "cubemapAssetPath": "Assets/Cubemaps/sunsetSkybox.cube"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ This engine has been created by [Horizons Games](https://github.com/Horizons-Gam
 **Shadows**
 - Directional light shadows implemented with Sample Distribution shadow maps (SDSM)
 - Variance Shadow Mapping (VSM) for smoother shadows around the edges.
+- Cascade Shadow Maps implemented in order to improve shadow resolution in big scenes
 
 **Component Line**
 
@@ -167,6 +168,7 @@ You can drag and drop different models and edit it's meshes and textures (loadin
 - F4 to toggle VSM on/off
 - F5 to change the rendered buffer texture
 - F6 to toggle SSAO on/off
+- F7 to toggle CSM debugging on/off
 
 # Note
 

--- a/Source/DataModels/Components/ComponentDirLight.cpp
+++ b/Source/DataModels/Components/ComponentDirLight.cpp
@@ -23,24 +23,24 @@
 
 ComponentDirLight::ComponentDirLight() : ComponentLight(LightType::DIRECTIONAL, false)
 {
-	shadowBias = float2(0.006f, 0.0009f);
+	shadowBias = float2(0.0999f, 0.005f);
 }
 
 ComponentDirLight::ComponentDirLight(GameObject* parent) : ComponentLight(LightType::DIRECTIONAL, parent, false)
 {
-	shadowBias = float2(0.006f, 0.0009f);
+	shadowBias = float2(0.0999f, 0.005f);
 }
 
 ComponentDirLight::ComponentDirLight(const float3& color, float intensity) :
 	ComponentLight(LightType::DIRECTIONAL, color, intensity, false)
 {
-	shadowBias = float2(0.006f, 0.0009f);
+	shadowBias = float2(0.0999f, 0.005f);
 }
 
 ComponentDirLight::ComponentDirLight(const float3& color, float intensity, GameObject* parent) :
 	ComponentLight(LightType::DIRECTIONAL, color, intensity, parent, false)
 {
-	shadowBias = float2(0.006f, 0.0009f);
+	shadowBias = float2(0.0999f, 0.005f);
 }
 
 ComponentDirLight::~ComponentDirLight()

--- a/Source/DataModels/Components/ComponentLine.cpp
+++ b/Source/DataModels/Components/ComponentLine.cpp
@@ -164,7 +164,8 @@ void ComponentLine::Render()
 {
 	ModuleCamera* camera = App->GetModule<ModuleCamera>();
 	ComponentTransform* transform = GetOwner()->GetComponent<ComponentTransform>();
-	if (camera->GetCamera()->IsInside(transform->GetEncapsuledAABB()))
+
+	if (IsEnabled() && camera->GetCamera()->IsInside(transform->GetEncapsuledAABB()))
 	{
 #ifdef ENGINE
 		//Draw the BoundingBox of ComponentLine

--- a/Source/DataModels/PostProcess/SSAO.cpp
+++ b/Source/DataModels/PostProcess/SSAO.cpp
@@ -5,7 +5,7 @@
 
 #include "Program/Program.h"
 
-#define BIAS 0.025f
+#define BIAS 0.05f
 #define RADIUS 1.5f
 
 SSAO::SSAO() : enabled(true)

--- a/Source/DataModels/Program/Program.cpp
+++ b/Source/DataModels/Program/Program.cpp
@@ -8,6 +8,43 @@
 
 Program::Program(unsigned vertexShader,
 				 unsigned fragmentShader,
+				 unsigned geometryShader,
+				 const std::string& vtxShaderFileName,
+				 const std::string& frgShaderFileName,
+				 const std::string& gtyShaderFileName,
+				 const std::string& programName) :
+	vertexShaderFileName(vtxShaderFileName),
+	fragmentShaderFileName(frgShaderFileName),
+	geometryShaderFileName(gtyShaderFileName),
+	programName(programName),
+	id(glCreateProgram())
+{
+	glAttachShader(id, vertexShader);
+	glAttachShader(id, fragmentShader);
+	glAttachShader(id, geometryShader);
+	glLinkProgram(id);
+
+	int res;
+	glGetProgramiv(id, GL_LINK_STATUS, &res);
+	if (res == GL_FALSE)
+	{
+		int len = 0;
+		glGetProgramiv(id, GL_INFO_LOG_LENGTH, &len);
+		if (len > 0)
+		{
+			int written = 0;
+			char* info = (char*)malloc(len);
+			glGetProgramInfoLog(id, len, &written, info);
+			LOG_INFO("Program Log Info: {}", info);
+			free(info);
+		}
+		SDL_assert(SDL_FALSE && "Problem compiling shaders, read console");
+		id = 0;
+	}
+}
+
+Program::Program(unsigned vertexShader,
+				 unsigned fragmentShader,
 				 const std::string& vtxShaderFileName,
 				 const std::string& frgShaderFileName,
 				 const std::string& programName) :

--- a/Source/DataModels/Program/Program.h
+++ b/Source/DataModels/Program/Program.h
@@ -7,6 +7,14 @@ class Program
 public:
 	Program(unsigned vertexShader,
 			unsigned fragmentShader,
+			unsigned geometryShader,
+			const std::string& vtxShaderFileName,
+			const std::string& frgShaderFileName,
+			const std::string& gtyShaderFileName,
+			const std::string& programName);
+
+	Program(unsigned vertexShader,
+			unsigned fragmentShader,
 			const std::string& vtxShaderFileName,
 			const std::string& frgShaderFileName,
 			const std::string& programName);
@@ -51,6 +59,7 @@ private:
 	unsigned id;
 	std::string vertexShaderFileName;
 	std::string fragmentShaderFileName;
+	std::string geometryShaderFileName;
 	std::string computeShaderFileName;
 	std::string programName;
 };

--- a/Source/DataModels/Render/Shadows.cpp
+++ b/Source/DataModels/Render/Shadows.cpp
@@ -32,9 +32,15 @@ Shadows::Shadows()
 {
 	shadowMapBuffer = 0;
 	gShadowMaps = 0;
+	parallelReductionInFrameBuffer = 0;
 	parallelReductionInTexture = 0;
+	parallelReductionOutFrameBuffer = 0;
 	parallelReductionOutTexture = 0;
 	minMaxBuffer = 0;
+	shadowVarianceFrameBuffer = 0;
+	shadowVarianceTexture = 0;
+	uboFrustums = 0;
+	uboCascadeDistances = 0;
 
 	for (unsigned i = 0; i < GAUSSIAN_BLUR_SHADOW_MAP; ++i)
 	{

--- a/Source/DataModels/Render/Shadows.cpp
+++ b/Source/DataModels/Render/Shadows.cpp
@@ -287,10 +287,6 @@ void Shadows::RenderShadowMap(const GameObject* light, const float2& minMax, Cam
 	float lightNear = S / (T + minMax[0]);
 	float lightFar = S / (T + minMax[1]);
 
-	if (lightNear > lightFar) {
-		lightNear = 0.1f;
-	}
-
 	cameraFrustum->SetViewPlaneDistances(lightNear, lightFar);
 
 	// Compute whole camera frustum to do culling only once

--- a/Source/DataModels/Render/Shadows.cpp
+++ b/Source/DataModels/Render/Shadows.cpp
@@ -1,0 +1,452 @@
+#include "StdAfx.h"
+#include "Shadows.h"
+
+#include "Application.h"
+
+#include "Batch/BatchManager.h"
+
+#include "Camera/Camera.h"
+#include "Camera/CameraGameObject.h"
+
+#include "Components/ComponentCamera.h"
+#include "Components/ComponentTransform.h"
+
+#include "GameObject/GameObject.h"
+
+#include "GBuffer/GBuffer.h"
+
+#include "Geometry/Frustum.h"
+
+#include "Modules/ModuleCamera.h"
+#include "Modules/ModuleProgram.h"
+#include "Modules/ModuleRender.h"
+#include "Modules/ModuleScene.h"
+
+#include "Program/Program.h";
+
+#include "Scene/Scene.h"
+
+#include "debugdraw.h"
+
+Shadows::Shadows()
+{
+	shadowMapBuffer = 0;
+	gShadowMaps = 0;
+	parallelReductionInTexture = 0;
+	parallelReductionOutTexture = 0;
+	minMaxBuffer = 0;
+
+	for (unsigned i = 0; i < GAUSSIAN_BLUR_SHADOW_MAP; ++i)
+	{
+		blurShadowMapBuffer[i] = 0;
+		gBluredShadowMaps[i] = 0;
+	}
+
+	for (unsigned i = 0; i <= FRUSTUM_PARTITIONS; ++i)
+	{
+		frustums[i] = new Frustum();
+	}
+
+	useShadows = true;
+	useVarianceShadowMapping = true;
+	useCSMDebug = false;
+}
+
+Shadows::~Shadows()
+{
+	for (unsigned i = 0; i <= FRUSTUM_PARTITIONS; ++i)
+	{
+		delete frustums[i];
+	}
+
+	CleanUp();
+}
+
+void Shadows::CleanUp()
+{
+	glDeleteFramebuffers(1, &shadowMapBuffer);
+	glDeleteTextures(1, &gShadowMaps);
+
+	glDeleteFramebuffers(GAUSSIAN_BLUR_SHADOW_MAP, &blurShadowMapBuffer[0]);
+	glDeleteTextures(GAUSSIAN_BLUR_SHADOW_MAP, &gBluredShadowMaps[0]);
+
+	glDeleteTextures(1, &parallelReductionInTexture);
+	glDeleteTextures(1, &parallelReductionOutTexture);
+	glDeleteTextures(1, &shadowVarianceTexture);
+
+	glDeleteBuffers(1, &minMaxBuffer);
+	glDeleteBuffers(1, &uboFrustums);
+	glDeleteBuffers(1, &uboCascadeDistances);
+}
+
+void Shadows::InitBuffers()
+{
+	glGenFramebuffers(1, &shadowMapBuffer);
+	glGenTextures(1, &gShadowMaps);
+
+	glGenFramebuffers(GAUSSIAN_BLUR_SHADOW_MAP, &blurShadowMapBuffer[0]);
+	glGenTextures(GAUSSIAN_BLUR_SHADOW_MAP, &gBluredShadowMaps[0]);
+
+	glGenTextures(1, &parallelReductionInTexture);
+	glGenTextures(1, &parallelReductionOutTexture);
+	glGenTextures(1, &shadowVarianceTexture);
+
+	glGenBuffers(1, &minMaxBuffer);
+
+	glGenBuffers(1, &uboFrustums);
+	glGenBuffers(1, &uboCascadeDistances);
+}
+
+void Shadows::UpdateBuffers(unsigned width, unsigned height)
+{
+	screenSize = std::make_pair(width, height);
+
+	// Shadow Mapping buffers
+	glBindFramebuffer(GL_FRAMEBUFFER, shadowMapBuffer);
+
+	glBindTexture(GL_TEXTURE_2D_ARRAY, gShadowMaps);
+	glTexImage3D(GL_TEXTURE_2D_ARRAY, 
+				 0,
+				 GL_DEPTH_COMPONENT32F, 
+				 screenSize.first, screenSize.second, 
+				 static_cast<GLint>(FRUSTUM_PARTITIONS + 1),
+				 0,
+				 GL_DEPTH_COMPONENT,
+				 GL_FLOAT, 
+				 NULL);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
+
+	glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, gShadowMaps, 0);
+
+	glDrawBuffer(GL_NONE);
+	glReadBuffer(GL_NONE);
+
+	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+	{
+		LOG_ERROR("ERROR::FRAMEBUFFER:: Shadow Map framebuffer not completed!");
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	glBindTexture(GL_TEXTURE_2D, parallelReductionInTexture);
+	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RG32F, screenSize.first, screenSize.second);
+	glBindTexture(GL_TEXTURE_2D, parallelReductionOutTexture);
+	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RG32F, screenSize.first, screenSize.second);
+
+	//VSM Buffers
+
+	glBindTexture(GL_TEXTURE_2D_ARRAY, shadowVarianceTexture);
+	glTexStorage3D(GL_TEXTURE_2D_ARRAY, 1, GL_RG32F, screenSize.first, screenSize.second, 
+		           static_cast<GLint>(FRUSTUM_PARTITIONS + 1));
+
+	for (unsigned i = 0; i < GAUSSIAN_BLUR_SHADOW_MAP; ++i)
+	{
+		glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[i]);
+
+		glBindTexture(GL_TEXTURE_2D_ARRAY, gBluredShadowMaps[i]);
+		glTexImage3D(GL_TEXTURE_2D_ARRAY, 
+					 0, 
+					 GL_RG32F, 
+					 screenSize.first, screenSize.second, 
+					 static_cast<GLint>(FRUSTUM_PARTITIONS + 1),
+					 0, 
+					 GL_RG, 
+					 GL_FLOAT, 
+					 NULL);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glFramebufferTexture(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, gBluredShadowMaps[i], 0);
+
+		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+		{
+			LOG_ERROR("ERROR::FRAMEBUFFER:: Blured Shadow Map framebuffer (num {}) not completed!", i);
+		}
+	}
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	glBindBuffer(GL_UNIFORM_BUFFER, uboFrustums);
+	glBindBufferRange(GL_UNIFORM_BUFFER, 2, uboFrustums, 0, sizeof(LightSpaceMatrices));
+
+	glBindBuffer(GL_UNIFORM_BUFFER, uboCascadeDistances);
+	glBindBufferRange(GL_UNIFORM_BUFFER, 3, uboCascadeDistances, 0, sizeof(CascadePlaneDistances));
+
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+}
+
+void Shadows::BindShadowMaps(Program* program)
+{
+	glActiveTexture(GL_TEXTURE5);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, useVarianceShadowMapping ?
+		gBluredShadowMaps[GAUSSIAN_BLUR_SHADOW_MAP - 1] : gShadowMaps);
+
+	glBindBuffer(GL_UNIFORM_BUFFER, uboCascadeDistances);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(CascadePlaneDistances), &cascadeDistances, GL_STATIC_DRAW);
+
+	program->BindUniformFloat4x4("cameraViewMatrix", reinterpret_cast<const float*>(&cameraView), GL_TRUE);
+	program->BindUniformInt("toggleCSMDebug", static_cast<int>(useCSMDebug));
+}
+
+float2 Shadows::ParallelReduction(GBuffer* gBuffer)
+{
+	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::PARALLEL_REDUCTION);
+	program->Activate();
+
+	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Parallel Reduction")),
+		"Parallel Reduction");
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, gBuffer->GetDepthTexture());
+
+	//Use the texture as an image
+	glBindImageTexture(0, parallelReductionInTexture, 0, false, 0, GL_WRITE_ONLY, GL_RG32F);
+
+	program->BindUniformInt2("inSize", screenSize.first, screenSize.second);
+
+	unsigned int numGroupsX = (screenSize.first + (16 - 1)) / 16;
+	unsigned int numGroupsY = (screenSize.second + (8 - 1)) / 8;
+
+	glDispatchCompute(numGroupsX, numGroupsY, 1);
+	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+	GLuint srcTexture = parallelReductionInTexture;
+	GLuint dstTexture = parallelReductionOutTexture;
+
+	while (numGroupsX > 1 || numGroupsY > 1)
+	{
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, srcTexture);
+
+		//Use the texture as an image
+		glBindImageTexture(0, dstTexture, 0, false, 0, GL_WRITE_ONLY, GL_RG32F);
+
+		program->BindUniformInt2("inSize", numGroupsX, numGroupsY);
+
+		numGroupsX = (numGroupsX + (8 - 1)) / 8;
+		numGroupsY = (numGroupsY + (4 - 1)) / 4;
+
+		glDispatchCompute(numGroupsX, numGroupsY, 1);
+		glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+		std::swap(srcTexture, dstTexture);
+	}
+
+	glPopDebugGroup();
+
+	program->Deactivate();
+
+	program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::MIN_MAX);
+	program->Activate();
+
+	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Min Max")), "Min Max");
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, srcTexture);
+
+	float2 minMax(0.0f, 0.0f);
+
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, minMaxBuffer);
+	glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(minMax), &minMax[0], GL_DYNAMIC_DRAW);
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, minMaxBuffer);
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
+
+	glDispatchCompute(1, 1, 1);
+	glMemoryBarrier(GL_BUFFER_UPDATE_BARRIER_BIT);
+
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, minMaxBuffer);
+	glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(minMax), &minMax[0]);
+
+	glPopDebugGroup();
+
+	program->Deactivate();
+
+	//glGetTextureSubImage(srcTexture, 0, 0, 0, 0, 1, 1, 1, GL_RG, GL_FLOAT, sizeof(float2), &minMax);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	return minMax;
+}
+
+void Shadows::RenderShadowMap(const GameObject* light, const float2& minMax, Camera* camera)
+{
+	math::Frustum* cameraFrustum = new Frustum(*camera->GetFrustum());
+	
+	// SDSM: Calculus for the final near an far planes
+	float n = cameraFrustum->NearPlaneDistance();
+	float f = cameraFrustum->FarPlaneDistance();
+	float T = -(n + f) / (f - n);
+	float S = (-2 * f * n) / (f - n);
+	float lightNear = S / (T + minMax[0]);
+	float lightFar = S / (T + minMax[1]);
+
+	if (lightNear > lightFar) {
+		lightNear = 0.1f;
+	}
+
+	cameraFrustum->SetViewPlaneDistances(lightNear, lightFar);
+
+	// Compute whole camera frustum to do culling only once
+	math::Frustum frustum = ComputeLightFrustum(light, cameraFrustum);
+	std::vector<GameObject*> objectsInFrustum =
+		App->GetModule<ModuleScene>()->GetLoadedScene()->ObtainObjectsInFrustum(&frustum);
+
+	// Calculate sub frustum
+	PartitionIntoSubFrustums(cameraFrustum);
+
+	for (int i = 0; i <= FRUSTUM_PARTITIONS; ++i)
+	{
+		frustum = ComputeLightFrustum(light, frustums[i]);
+
+		frustumMatrices.proj[i] = frustum.ProjectionMatrix();
+		frustumMatrices.view[i] = frustum.ViewMatrix();
+	}
+
+	cameraView = cameraFrustum->ViewMatrix();
+
+	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Shadow Mapping")),
+		"Shadow Mapping");
+
+	// Program binding
+	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::SHADOW_MAPPING);
+	program->Activate();
+
+	glBindFramebuffer(GL_FRAMEBUFFER, shadowMapBuffer);
+	glClear(GL_DEPTH_BUFFER_BIT);
+
+	glBindBuffer(GL_UNIFORM_BUFFER, uboFrustums);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(LightSpaceMatrices), &frustumMatrices, GL_STATIC_DRAW);
+
+	ModuleRender* render = App->GetModule<ModuleRender>();
+	render->GetBatchManager()->DrawMeshes(objectsInFrustum, float3(frustum.Pos()));
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+	program->Deactivate();
+
+	glPopDebugGroup();
+}
+
+void Shadows::ShadowDepthVariance()
+{
+	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, std::strlen("Shadow Depth Variance"), "Shadow Depth Variance");
+
+	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::SHADOW_DEPTH_VARIANCE);
+	program->Activate();
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, gShadowMaps);
+
+	glBindImageTexture(0, shadowVarianceTexture, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_RG32F);
+
+	program->BindUniformInt2("inSize", screenSize.first, screenSize.second);
+	program->BindUniformInt("cascadeCount", FRUSTUM_PARTITIONS + 1);
+
+	unsigned int numGroupsX = (screenSize.first + (16 - 1)) / 16;
+	unsigned int numGroupsY = (screenSize.second + (8 - 1)) / 8;
+
+	glDispatchCompute(numGroupsX, numGroupsY, 1);
+	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+
+	program->Deactivate();
+
+	glPopDebugGroup();
+}
+
+void Shadows::GaussianBlur()
+{
+	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, std::strlen("Gaussian Blur"), "Gaussian Blur");
+
+	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::GAUSSIAN_BLUR_3D);
+	program->Activate();
+
+	glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[0]);
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, shadowVarianceTexture);
+
+	program->BindUniformFloat2("invSize", float2(1.0f / screenSize.first, 1.0f / screenSize.second));
+	program->BindUniformFloat2("blurDirection", float2(1.0f, 0.0f));
+
+	glDrawArrays(GL_TRIANGLES, 0, 3);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[1]);
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D_ARRAY, gBluredShadowMaps[0]);
+
+	program->BindUniformFloat2("blurDirection", float2(0.0f, 1.0f));
+
+	glDrawArrays(GL_TRIANGLES, 0, 3);
+
+	program->Deactivate();
+
+	glPopDebugGroup();
+}
+
+void Shadows::PartitionIntoSubFrustums(Frustum* frustum)
+{
+	float lastNearPlane = frustum->NearPlaneDistance();
+
+	for (unsigned i = 0; i < FRUSTUM_PARTITIONS; ++i)
+	{
+		float farPlane = frustum->FarPlaneDistance() * frustumIntervals[i] + lastNearPlane;
+		
+		*frustums[i] = *frustum;
+		frustums[i]->SetViewPlaneDistances(lastNearPlane, farPlane);
+
+		cascadeDistances.farDistances[i] = farPlane;
+
+		lastNearPlane = farPlane;
+	}
+
+	*frustums[FRUSTUM_PARTITIONS] = *frustum;
+	frustums[FRUSTUM_PARTITIONS]->SetViewPlaneDistances(lastNearPlane, frustum->FarPlaneDistance());
+
+	cascadeDistances.farDistances[FRUSTUM_PARTITIONS] = frustum->FarPlaneDistance();
+}
+
+Frustum& Shadows::ComputeLightFrustum(const GameObject* light, Frustum* cameraFrustum)
+{
+	float3 corners[8];
+	cameraFrustum->GetCornerPoints(corners);
+
+	const float3 sphereCenter = cameraFrustum->CenterPoint();
+	float sphereRadius = 0.0f;
+
+	for (unsigned int i = 0; i < 8; ++i)
+	{
+		sphereRadius = std::max(sphereRadius, sphereCenter.Distance(corners[i]));
+	}
+
+	// Compute bounding box
+	math::Frustum frustum;
+
+	const ComponentTransform* lightTransform = light->GetComponent<ComponentTransform>();
+	const float3& lightPos = lightTransform->GetGlobalPosition();
+
+	float3 lightFront = lightTransform->GetGlobalForward();
+	float3 lightRight = Cross(lightFront, float3(0.0f, 1.0f, 0.0f)).Normalized();
+	float3 lifghtUp = math::Cross(lightRight, lightFront).Normalized();
+	frustum.SetKind(FrustumProjectiveSpace::FrustumSpaceGL, FrustumHandedness::FrustumRightHanded);
+	frustum.SetPos(sphereCenter - lightFront * sphereRadius);
+	frustum.SetFront(lightFront);
+	frustum.SetUp(lifghtUp);
+	frustum.SetViewPlaneDistances(0.0f, sphereRadius * 2.0f);
+	frustum.SetOrthographic(sphereRadius * 2.0f, sphereRadius * 2.0f);
+
+	//dd::frustum(cameraFrustum->ViewProjMatrix().Inverted(), dd::colors::Yellow);
+	//dd::frustum(frustum.ViewProjMatrix().Inverted(), dd::colors::Yellow);;
+
+	return frustum;
+}

--- a/Source/DataModels/Render/Shadows.h
+++ b/Source/DataModels/Render/Shadows.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "GL/glew.h"
+
+#define GAUSSIAN_BLUR_SHADOW_MAP 2
+
+#define FRUSTUM_PARTITIONS 2
+
+constexpr float frustumIntervals[FRUSTUM_PARTITIONS] = { 0.05f, 0.15f };
+
+class Camera;
+class GBuffer;
+class Program;
+
+class Shadows
+{
+public:
+	Shadows();
+	~Shadows();
+
+	void CleanUp();
+	void InitBuffers();
+	void UpdateBuffers(unsigned width, unsigned height);
+
+	void BindShadowMaps(Program* program);
+
+	float2 ParallelReduction(GBuffer* gBuffer);
+	void RenderShadowMap(const GameObject* light, const float2& minMax, Camera* camera);
+	void ShadowDepthVariance();
+	void GaussianBlur();
+
+	bool UseShadows() const;
+	bool UseVSM() const;
+
+	void ToggleShadows();
+	void ToggleVSM();
+	void ToggleCSMDebug();
+
+private:
+	void PartitionIntoSubFrustums(Frustum* frustum);
+	Frustum& ComputeLightFrustum(const GameObject* light, Frustum* cameraFrustum);
+
+private:
+	struct LightSpaceMatrices
+	{
+		float4x4 proj[FRUSTUM_PARTITIONS + 1];
+		float4x4 view[FRUSTUM_PARTITIONS + 1];
+	};
+
+	struct CascadePlaneDistances
+	{
+		float farDistances[FRUSTUM_PARTITIONS + 1];
+	};
+
+	// Shadow Mapping buffers and textures
+	GLuint shadowMapBuffer = 0;
+	GLuint gShadowMaps = 0;
+	GLuint parallelReductionInTexture = 0;
+	GLuint parallelReductionOutTexture = 0;
+	GLuint minMaxBuffer = 0;
+
+	// Variance Shadow Mapping buffers and textures
+	GLuint shadowVarianceTexture = 0;
+	GLuint blurShadowMapBuffer[GAUSSIAN_BLUR_SHADOW_MAP];
+	GLuint gBluredShadowMaps[GAUSSIAN_BLUR_SHADOW_MAP];
+
+	GLuint uboFrustums;
+	GLuint uboCascadeDistances;
+
+	float4x4 cameraView;
+
+	Frustum* frustums[FRUSTUM_PARTITIONS + 1];
+	LightSpaceMatrices frustumMatrices;
+	CascadePlaneDistances cascadeDistances;
+
+	bool useShadows;
+	bool useVarianceShadowMapping;
+	bool useCSMDebug;
+
+	std::pair<unsigned, unsigned> screenSize;
+};
+
+inline bool Shadows::UseShadows() const
+{
+	return useShadows;
+}
+
+inline bool Shadows::UseVSM() const
+{
+	return useVarianceShadowMapping;
+}
+
+inline void Shadows::ToggleShadows()
+{
+	useShadows = !useShadows;
+}
+
+inline void Shadows::ToggleVSM()
+{
+	useVarianceShadowMapping = !useVarianceShadowMapping;
+}
+
+inline void Shadows::ToggleCSMDebug()
+{
+	useCSMDebug = !useCSMDebug;
+}

--- a/Source/DataModels/Render/Shadows.h
+++ b/Source/DataModels/Render/Shadows.h
@@ -55,11 +55,14 @@ private:
 	// Shadow Mapping buffers and textures
 	GLuint shadowMapBuffer = 0;
 	GLuint gShadowMaps = 0;
+	GLuint parallelReductionInFrameBuffer = 0;
 	GLuint parallelReductionInTexture = 0;
+	GLuint parallelReductionOutFrameBuffer = 0;
 	GLuint parallelReductionOutTexture = 0;
 	GLuint minMaxBuffer = 0;
 
 	// Variance Shadow Mapping buffers and textures
+	GLuint shadowVarianceFrameBuffer = 0;
 	GLuint shadowVarianceTexture = 0;
 	GLuint blurShadowMapBuffer[GAUSSIAN_BLUR_SHADOW_MAP];
 	GLuint gBluredShadowMaps[GAUSSIAN_BLUR_SHADOW_MAP];

--- a/Source/DataModels/Render/Shadows.h
+++ b/Source/DataModels/Render/Shadows.h
@@ -53,17 +53,17 @@ private:
 	};
 
 	// Shadow Mapping buffers and textures
-	GLuint shadowMapBuffer = 0;
-	GLuint gShadowMaps = 0;
-	GLuint parallelReductionInFrameBuffer = 0;
-	GLuint parallelReductionInTexture = 0;
-	GLuint parallelReductionOutFrameBuffer = 0;
-	GLuint parallelReductionOutTexture = 0;
-	GLuint minMaxBuffer = 0;
+	GLuint shadowMapBuffer;
+	GLuint gShadowMaps;
+	GLuint parallelReductionInFrameBuffer;
+	GLuint parallelReductionInTexture;
+	GLuint parallelReductionOutFrameBuffer;
+	GLuint parallelReductionOutTexture;
+	GLuint minMaxBuffer;
 
 	// Variance Shadow Mapping buffers and textures
-	GLuint shadowVarianceFrameBuffer = 0;
-	GLuint shadowVarianceTexture = 0;
+	GLuint shadowVarianceFrameBuffer;
+	GLuint shadowVarianceTexture;
 	GLuint blurShadowMapBuffer[GAUSSIAN_BLUR_SHADOW_MAP];
 	GLuint gBluredShadowMaps[GAUSSIAN_BLUR_SHADOW_MAP];
 

--- a/Source/DataModels/Render/Shadows.h
+++ b/Source/DataModels/Render/Shadows.h
@@ -4,9 +4,9 @@
 
 #define GAUSSIAN_BLUR_SHADOW_MAP 2
 
-#define FRUSTUM_PARTITIONS 2
+#define FRUSTUM_PARTITIONS 1
 
-constexpr float frustumIntervals[FRUSTUM_PARTITIONS] = { 0.05f, 0.15f };
+constexpr float frustumIntervals[FRUSTUM_PARTITIONS] = { 0.15f };
 
 class Camera;
 class GBuffer;

--- a/Source/DataModels/Scene/Scene.cpp
+++ b/Source/DataModels/Scene/Scene.cpp
@@ -206,7 +206,7 @@ void Scene::CalculateNonStaticObjectsInFrustum(const math::Frustum* frustum, Gam
 		if (go->HasComponent<ComponentMeshRenderer>())
 		{
 			ComponentMeshRenderer* mesh = go->GetComponentInternal<ComponentMeshRenderer>();
-			if (go->IsActive() && (mesh == nullptr || mesh->IsEnabled()))
+			if (go->IsActive() && (mesh != nullptr || mesh->IsEnabled()))
 			{
 				gos.push_back(go);
 			}

--- a/Source/Engine.vcxproj
+++ b/Source/Engine.vcxproj
@@ -426,6 +426,7 @@
     <ClCompile Include="DataModels\Components\ComponentAgent.cpp" />
     <ClCompile Include="DataModels\Components\ComponentObstacle.cpp" />
     <ClCompile Include="DataModels\PostProcess\SSAO.cpp" />
+    <ClCompile Include="DataModels\Render\Shadows.cpp" />
     <ClCompile Include="DataModels\Resources\ResourceNavMesh.cpp" />
     <ClCompile Include="DataModels\Animation\StateMachine.cpp" />
     <ClCompile Include="Auxiliar\SceneLoader.cpp" />
@@ -953,6 +954,7 @@
     <ClInclude Include="DataModels\Components\ComponentRender.h" />
     <ClInclude Include="DataModels\Components\ComponentTrail.h" />
     <ClInclude Include="DataModels\PostProcess\SSAO.h" />
+    <ClInclude Include="DataModels\Render\Shadows.h" />
     <ClInclude Include="DataModels\Windows\EditorWindows\ImporterWindows\WindowLineTexture.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseGame|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugGame|x64'">true</ExcludedFromBuild>

--- a/Source/Engine.vcxproj.filters
+++ b/Source/Engine.vcxproj.filters
@@ -773,6 +773,9 @@
     <ClCompile Include="DataModels\PostProcess\SSAO.cpp">
       <Filter>DataModels\PostProcess</Filter>
     </ClCompile>
+    <ClCompile Include="DataModels\Render\Shadows.cpp">
+      <Filter>DataModels\Render</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DataModels\Timer\Timer.h">
@@ -1591,6 +1594,9 @@
     <ClInclude Include="DataModels\PostProcess\SSAO.h">
       <Filter>DataModels\PostProcess</Filter>
     </ClInclude>
+    <ClInclude Include="DataModels\Render\Shadows.h">
+      <Filter>DataModels\Render</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Auxiliar">
@@ -1796,6 +1802,9 @@
     </Filter>
     <Filter Include="DataModels\PostProcess">
       <UniqueIdentifier>{378aa69b-879a-45bc-8d90-4c8dc788a32a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="DataModels\Render">
+      <UniqueIdentifier>{701145da-de98-4a67-be5b-f78bd0c29386}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Modules/ModuleInput.cpp
+++ b/Source/Modules/ModuleInput.cpp
@@ -348,6 +348,11 @@ UpdateStatus ModuleInput::Update()
 		App->GetModule<ModuleRender>()->ToggleSSAO();
 	}
 
+	if (keysState[SDL_SCANCODE_F7] == KeyState::DOWN && SDL_ShowCursor(SDL_QUERY))
+	{
+		App->GetModule<ModuleRender>()->ToggleCSMDebug();
+	}
+
 #endif
 
 	return UpdateStatus::UPDATE_CONTINUE;

--- a/Source/Modules/ModuleProgram.cpp
+++ b/Source/Modules/ModuleProgram.cpp
@@ -82,7 +82,8 @@ bool ModuleProgram::Start()
 	
 	programs.push_back(CreateProgram("default_vertex.glsl", "gBuffer_Specular_fs.glsl", "GSpecular"));
 
-	programs.push_back(CreateProgram("shadow_map_vertex.glsl", "shadow_map_fragment.glsl", "ShadowMapping"));
+	programs.push_back(CreateProgram("shadow_map_vertex.glsl", "shadow_map_fragment.glsl", "shadow_map_geometry.glsl", 
+		                             "ShadowMapping"));
 
 	programs.push_back(CreateProgram("parallel_reduction.glsl", "ParallelReduction"));
 	
@@ -91,6 +92,9 @@ bool ModuleProgram::Start()
 	programs.push_back(CreateProgram("shadow_depth_variance.glsl", "ShadowDepthVariance"));
 
 	programs.push_back(CreateProgram("render_clip_space_vertex.glsl", "gaussian_blur.glsl", "GaussianBlur"));
+
+	programs.push_back(CreateProgram("render_clip_space_vertex_3d.glsl", "gaussian_blur_3d_fragment.glsl", 
+									 "gaussian_blur_3d_geometry.glsl", "GaussianBlur3D"));
 	
 	//programs.push_back(CreateProgram("render_clip_space_vertex.glsl", "bloom.glsl", "Bloom"));
 
@@ -123,17 +127,63 @@ void ModuleProgram::UpdateProgram(const std::string& vtxShaderFileName,
 	}
 }
 
+std::unique_ptr<Program> ModuleProgram::CreateProgram(const std::string& vtxShaderFileName, 
+													  const std::string& frgShaderFileName, 
+													  const std::string& gtyShaderFileName, 
+													  const std::string& programName)
+{
+	char* vertexBuffer{};
+	App->GetModule<ModuleFileSystem>()->Load((rootPath + vtxShaderFileName).c_str(), vertexBuffer);
+	LOG_INFO("Compiling shader {}", vtxShaderFileName);
+	unsigned vertexShader = CompileShader(GL_VERTEX_SHADER, vertexBuffer);
+	delete vertexBuffer;
+
+	char* fragmentBuffer{};
+	App->GetModule<ModuleFileSystem>()->Load((rootPath + frgShaderFileName).c_str(), fragmentBuffer);
+	LOG_INFO("Compiling shader {}", frgShaderFileName);
+	unsigned fragmentShader = CompileShader(GL_FRAGMENT_SHADER, fragmentBuffer);
+	delete fragmentBuffer;
+
+	char* geometryBuffer{};
+	App->GetModule<ModuleFileSystem>()->Load((rootPath + gtyShaderFileName).c_str(), geometryBuffer);
+	LOG_INFO("Compiling shader {}", gtyShaderFileName);
+	unsigned geometryShader = CompileShader(GL_GEOMETRY_SHADER, geometryBuffer);
+	delete geometryBuffer;
+
+	if (vertexShader == 0 || fragmentShader == 0 || geometryShader == 0)
+	{
+		return nullptr;
+	}
+
+	std::unique_ptr<Program> program =
+		std::make_unique<Program>(vertexShader, fragmentShader, geometryShader,
+								  vtxShaderFileName, frgShaderFileName, gtyShaderFileName,  programName);
+
+	if (!program->IsValidProgram())
+	{
+		return nullptr;
+	}
+
+	glDeleteShader(vertexShader);
+	glDeleteShader(fragmentShader);
+	glDeleteShader(geometryShader);
+
+	return program;
+}
+
 std::unique_ptr<Program> ModuleProgram::CreateProgram(const std::string& vtxShaderFileName,
 													  const std::string& frgShaderFileName,
 													  const std::string& programName)
 {
 	char* vertexBuffer{};
 	App->GetModule<ModuleFileSystem>()->Load((rootPath + vtxShaderFileName).c_str(), vertexBuffer);
+	LOG_INFO("Compiling shader {}", vtxShaderFileName);
 	unsigned vertexShader = CompileShader (GL_VERTEX_SHADER, vertexBuffer);
 	delete vertexBuffer;
 
 	char* fragmentBuffer{};
 	App->GetModule<ModuleFileSystem>()->Load((rootPath + frgShaderFileName).c_str(), fragmentBuffer);
+	LOG_INFO("Compiling shader {}", frgShaderFileName);
 	unsigned fragmentShader = CompileShader (GL_FRAGMENT_SHADER,fragmentBuffer);
 	delete fragmentBuffer;
 
@@ -160,6 +210,7 @@ std::unique_ptr<Program> ModuleProgram::CreateProgram(const std::string& compute
 {
 	char* computeBuffer{};
 	App->GetModule<ModuleFileSystem>()->Load((rootPath + computeShaderName).c_str(), computeBuffer);
+	LOG_INFO("Compiling shader {}", computeShaderName);
 	unsigned computeShader = CompileShader(GL_COMPUTE_SHADER, computeBuffer);
 	delete computeBuffer;
 

--- a/Source/Modules/ModuleProgram.h
+++ b/Source/Modules/ModuleProgram.h
@@ -23,6 +23,7 @@ enum class ProgramType
 	MIN_MAX,
 	SHADOW_DEPTH_VARIANCE,
 	GAUSSIAN_BLUR,
+	GAUSSIAN_BLUR_3D,
 	//BLOOM,
 	KAWASE_DOWN,
 	KAWASE_UP,
@@ -49,6 +50,10 @@ public:
 	Program* GetProgram(ProgramType type) const;
 
 private:
+	std::unique_ptr<Program> CreateProgram(const std::string& vtxShaderFileName,
+										   const std::string& frgShaderFileName,
+										   const std::string& gtyShaderFileName,
+										   const std::string& programName);
 	std::unique_ptr<Program> CreateProgram(const std::string& vtxShaderFileName,
 										   const std::string& frgShaderFileName,
 										   const std::string& programName);

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -383,8 +383,11 @@ UpdateStatus ModuleRender::Update()
 		ComponentDirLight* directLight = static_cast<ComponentDirLight*>(
 			App->GetModule<ModuleScene>()->GetLoadedScene()->GetDirectionalLight()->GetComponent<ComponentLight>());
 
-		program->BindUniformFloat("minBias", directLight->shadowBias[0]);
-		program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
+		if (!shadows->UseVSM())
+		{
+			program->BindUniformFloat("minBias", directLight->shadowBias[0]);
+			program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
+		}
 	}
 	program->BindUniformInt("useShadows", static_cast<int>(shadows->UseShadows()));
 	program->BindUniformInt("useVSM", static_cast<int>(shadows->UseVSM()));

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -9,6 +9,7 @@
 #include "ModuleWindow.h"
 #include "ModuleNavigation.h"
 
+#include "Camera/Camera.h"
 #include "Camera/CameraGameObject.h"
 
 #include "Cubemap/Cubemap.h"
@@ -20,8 +21,6 @@
 #include "Components/ComponentTransform.h"
 #include "Components/ComponentLine.h"
 #include "Components/ComponentCamera.h"
-
-#include "Camera/CameraGameObject.h"
 
 #include "DataModels/Resources/ResourceMaterial.h"
 #include "DataModels/Batch/BatchManager.h"
@@ -35,7 +34,6 @@
 #include "Program/Program.h"
 
 #include "Scene/Scene.h"
-#include "Camera/Camera.h"
 
 #ifdef DEBUG
 	#include "optick.h"
@@ -140,7 +138,9 @@ ModuleRender::~ModuleRender()
 {
 	delete batchManager;
 	delete gBuffer;
+	delete shadows;
 	delete ssao;
+
 	objectsInFrustrumDistances.clear();
 	gameObjectsInFrustrum.clear();
 }
@@ -164,9 +164,8 @@ bool ModuleRender::Init()
 
 	batchManager = new BatchManager();
 	gBuffer = new GBuffer();
+	shadows = new Shadows();
 	ssao = new SSAO();
-	renderShadows = true;
-	varianceShadowMapping = true;
 
 	GLenum err = glewInit();
 	// check for errors
@@ -209,18 +208,7 @@ bool ModuleRender::Init()
 
 	glGenRenderbuffers(1, &depthStencilRenderBuffer);
 
-	// Shadow Buffers
-	glGenFramebuffers(1, &shadowMapBuffer);
-	glGenTextures(1, &gShadowMap);
-	glGenFramebuffers(GAUSSIAN_BLUR_SHADOW_MAP, &blurShadowMapBuffer[0]);
-	glGenTextures(GAUSSIAN_BLUR_SHADOW_MAP, &gBluredShadowMap[0]);
-
-	glGenTextures(1, &parallelReductionInTexture);
-	glGenTextures(1, &parallelReductionOutTexture);
-	glGenTextures(1, &shadowVarianceTexture);
-
-	glGenBuffers(1, &minMaxBuffer);
-
+	shadows->InitBuffers();
 	ssao->InitBuffers();
 
 	std::pair<int, int> windowSize = window->GetWindowSize();
@@ -277,29 +265,33 @@ UpdateStatus ModuleRender::Update()
 
 	GameObject* player = modulePlayer->GetPlayer(); // we can make all of this variables a class variable to save time
 
+	// Camera
+	Camera* checkedCamera = GetFrustumCheckedCamera();
+	Camera* engineCamera = App->GetModule<ModuleCamera>()->GetCamera();
+
 #ifdef ENGINE
 	if (App->IsOnPlayMode())
 #else
 	if (player)
 #endif
 	{
-		AddToRenderList(player);
+		AddToRenderList(player, checkedCamera);
 	}
 
 	GameObject* goSelected = App->GetModule<ModuleScene>()->GetSelectedGameObject();
 
-	FillRenderList(App->GetModule<ModuleScene>()->GetLoadedScene()->GetRootQuadtree());
+	FillRenderList(App->GetModule<ModuleScene>()->GetLoadedScene()->GetRootQuadtree(), checkedCamera);
 	
 	std::vector<GameObject*> nonStaticsGOs = App->GetModule<ModuleScene>()->GetLoadedScene()->GetNonStaticObjects();
 
 	for (GameObject* nonStaticObj : nonStaticsGOs)
 	{
-		AddToRenderList(nonStaticObj);
+		AddToRenderList(nonStaticObj, checkedCamera);
 	}
 	
 	if (goSelected)
 	{
-		AddToRenderList(goSelected);
+		AddToRenderList(goSelected, checkedCamera, true);
 	}
 
 	if (App->GetModule<ModuleDebugDraw>()->IsShowingBoundingBoxes())
@@ -314,8 +306,8 @@ UpdateStatus ModuleRender::Update()
 	BindCubemapToProgram(modProgram->GetProgram(ProgramType::DEFAULT));
 	BindCubemapToProgram(modProgram->GetProgram(ProgramType::SPECULAR));
 	BindCubemapToProgram(modProgram->GetProgram(ProgramType::DEFERRED_LIGHT));
-	BindCameraToProgram(modProgram->GetProgram(ProgramType::G_METALLIC));
-	BindCameraToProgram(modProgram->GetProgram(ProgramType::G_SPECULAR));
+	BindCameraToProgram(modProgram->GetProgram(ProgramType::G_METALLIC), engineCamera);
+	BindCameraToProgram(modProgram->GetProgram(ProgramType::G_SPECULAR), engineCamera);
 
 	// -------- DEFERRED GEOMETRY -----------
 	gBuffer->BindFrameBuffer();
@@ -341,30 +333,26 @@ UpdateStatus ModuleRender::Update()
 	}
 
 	// -------- SHADOW MAP --------
-	if (renderShadows)
+	if (shadows->UseShadows())
 	{
 		// ---- PARALLEL REDUCTION ----
-		Program* shadowProgram = modProgram->GetProgram(ProgramType::PARALLEL_REDUCTION);
-		float2 minMax = ParallelReduction(shadowProgram, w, h);
+		float2 minMax = shadows->ParallelReduction(gBuffer);
+		shadows->RenderShadowMap(loadedScene->GetDirectionalLight(), minMax, checkedCamera);
 
-		RenderShadowMap(loadedScene->GetDirectionalLight(), minMax);
-
-		if (varianceShadowMapping)
+		if (shadows->UseVSM())
 		{
-			ShadowDepthVariacne(w, h);
-			GaussianBlur(w, h);
+			shadows->ShadowDepthVariance();
+			shadows->GaussianBlur();
 		}
 	}
 	
 	Program* program;
 
 	// SSAO Calculus and Blurring
-	bool ssaoActivated = ssao->IsEnabled();
-
-	if (ssaoActivated)
+	if (ssao->IsEnabled())
 	{
 		program = modProgram->GetProgram(ProgramType::SSAO);
-		BindCameraToProgram(program);
+		BindCameraToProgram(program, engineCamera);
 		ssao->CalculateSSAO(program, w, h);
 
 		program = modProgram->GetProgram(ProgramType::GAUSSIAN_BLUR);
@@ -372,9 +360,9 @@ UpdateStatus ModuleRender::Update()
 	}
 
 	// -------- DEFERRED LIGHTING ---------------
-	BindCameraToProgram(modProgram->GetProgram(ProgramType::DEFAULT));
-	BindCameraToProgram(modProgram->GetProgram(ProgramType::SPECULAR));
-	BindCameraToProgram(modProgram->GetProgram(ProgramType::DEFERRED_LIGHT));
+	BindCameraToProgram(modProgram->GetProgram(ProgramType::DEFAULT), engineCamera);
+	BindCameraToProgram(modProgram->GetProgram(ProgramType::SPECULAR), engineCamera);
+	BindCameraToProgram(modProgram->GetProgram(ProgramType::DEFERRED_LIGHT), engineCamera);
 
 	// -------- DEFERRED LIGHTING ---------------
 	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, std::strlen("DEFERRED LIGHTING"), "DEFERRED LIGHTING");
@@ -388,30 +376,25 @@ UpdateStatus ModuleRender::Update()
 	gBuffer->BindTexture();
 
 	// Binding Shadow map depth buffer
-	if (renderShadows)
+	if (shadows->UseShadows())
 	{
-		glActiveTexture(GL_TEXTURE5);
-		glBindTexture(GL_TEXTURE_2D, varianceShadowMapping ? 
-			gBluredShadowMap[GAUSSIAN_BLUR_SHADOW_MAP - 1] : gShadowMap);
+		shadows->BindShadowMaps(program);
 
-		float4x4 lightSpaceMatrix = dirLightProj * dirLightView;
-		ComponentDirLight* directLight =
-			static_cast<ComponentDirLight*>
-			(App->GetModule<ModuleScene>()->GetLoadedScene()->GetDirectionalLight()->GetComponent<ComponentLight>());
+		ComponentDirLight* directLight = static_cast<ComponentDirLight*>(
+			App->GetModule<ModuleScene>()->GetLoadedScene()->GetDirectionalLight()->GetComponent<ComponentLight>());
 
-		program->BindUniformFloat4x4("lightSpaceMatrix", reinterpret_cast<const float*>(&lightSpaceMatrix), GL_TRUE);
 		program->BindUniformFloat("minBias", directLight->shadowBias[0]);
 		program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
 	}
-	program->BindUniformInt("useShadows", static_cast<int>(renderShadows));
-	program->BindUniformInt("useVSM", static_cast<int>(varianceShadowMapping));
-	program->BindUniformInt("useSSAO", static_cast<int>(ssaoActivated));
+	program->BindUniformInt("useShadows", static_cast<int>(shadows->UseShadows()));
+	program->BindUniformInt("useVSM", static_cast<int>(shadows->UseVSM()));
+	program->BindUniformInt("useSSAO", static_cast<int>(ssao->IsEnabled()));
 
 	//Use to debug other Gbuffer/value default = 0 position = 1 normal = 2 diffuse = 3 specular = 4 and emissive = 5
 	program->BindUniformInt("renderMode", modeRender);
 
 	// SSAO texture
-	if (ssaoActivated)
+	if (ssao->IsEnabled())
 	{
 		glActiveTexture(GL_TEXTURE6);
 		glBindTexture(GL_TEXTURE_2D, ssao->GetSSAOTexture());
@@ -603,15 +586,6 @@ bool ModuleRender::CleanUp()
 
 	glDeleteRenderbuffers(1, &depthStencilRenderBuffer);
 
-	glDeleteFramebuffers(1, &shadowMapBuffer);
-	glDeleteTextures(1, &gShadowMap);
-	glDeleteFramebuffers(GAUSSIAN_BLUR_SHADOW_MAP, &blurShadowMapBuffer[0]);
-	glDeleteTextures(GAUSSIAN_BLUR_SHADOW_MAP, &gBluredShadowMap[0]);
-
-	glDeleteTextures(1, &parallelReductionInTexture);
-	glDeleteTextures(1, &parallelReductionOutTexture);
-	glDeleteTextures(1, &shadowVarianceTexture);
-
 	return true;
 }
 
@@ -626,45 +600,7 @@ void ModuleRender::WindowResized(unsigned width, unsigned height)
 void ModuleRender::UpdateBuffers(unsigned width, unsigned height) //this is called twice
 {
 	gBuffer->InitGBuffer(width, height);
-	
-	// Shadow Map Depth Buffer
-	glBindFramebuffer(GL_FRAMEBUFFER, shadowMapBuffer);
-
-	glBindTexture(GL_TEXTURE_2D, gShadowMap);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-
-	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, gShadowMap, 0);
-
-	glDrawBuffer(GL_NONE);
-	glReadBuffer(GL_NONE);
-
-	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-	{
-		LOG_ERROR("ERROR::FRAMEBUFFER:: Shadow Map framebuffer not completed!");
-	}
-
-	for (unsigned i = 0; i < GAUSSIAN_BLUR_SHADOW_MAP; ++i)
-	{
-		glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[i]);
-
-		glBindTexture(GL_TEXTURE_2D, gBluredShadowMap[i]);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RG32F, width, height, 0, GL_RG, GL_FLOAT, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, gBluredShadowMap[i], 0);
-
-		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
-		{
-			LOG_ERROR("ERROR::FRAMEBUFFER:: Blured Shadow Map framebuffer (num {}) not completed!", i);
-		}
-	}
+	shadows->UpdateBuffers(width, height);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, frameBuffer[0]);
 
@@ -774,13 +710,6 @@ void ModuleRender::UpdateBuffers(unsigned width, unsigned height) //this is call
 		
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-	glBindTexture(GL_TEXTURE_2D, parallelReductionInTexture);
-	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RG32F, width, height);
-	glBindTexture(GL_TEXTURE_2D, parallelReductionOutTexture);
-	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RG32F, width, height);
-	glBindTexture(GL_TEXTURE_2D, shadowVarianceTexture);
-	glTexStorage2D(GL_TEXTURE_2D, 1, GL_RG32F, width, height);
-
 	glBindTexture(GL_TEXTURE_2D, 0); //Unbind the texture
 
 	// SSAO
@@ -788,14 +717,12 @@ void ModuleRender::UpdateBuffers(unsigned width, unsigned height) //this is call
 	ssao->SetTextures(gBuffer->GetPositionTexture(), gBuffer->GetNormalTexture());
 }
 
-void ModuleRender::FillRenderList(const Quadtree* quadtree)
+void ModuleRender::FillRenderList(const Quadtree* quadtree, Camera* camera)
 {
 	if (quadtree == nullptr)
 	{
 		return;
 	}
-
-	Camera* camera = GetFrustumCheckedCamera();
 		
 	float3 cameraPos = camera->GetPosition();
 
@@ -849,26 +776,23 @@ void ModuleRender::FillRenderList(const Quadtree* quadtree)
 				}
 			}
 
-			FillRenderList(quadtree->GetFrontRightNode()); // And also call all the children to render
-			FillRenderList(quadtree->GetFrontLeftNode());
-			FillRenderList(quadtree->GetBackRightNode());
-			FillRenderList(quadtree->GetBackLeftNode());
+			FillRenderList(quadtree->GetFrontRightNode(), camera); // And also call all the children to render
+			FillRenderList(quadtree->GetFrontLeftNode(), camera);
+			FillRenderList(quadtree->GetBackRightNode(), camera);
+			FillRenderList(quadtree->GetBackLeftNode(), camera);
 		}
 		else
 		{
-			FillRenderList(quadtree->GetFrontRightNode());
-			FillRenderList(quadtree->GetFrontLeftNode());
-			FillRenderList(quadtree->GetBackRightNode());
-			FillRenderList(quadtree->GetBackLeftNode());
+			FillRenderList(quadtree->GetFrontRightNode(), camera);
+			FillRenderList(quadtree->GetFrontLeftNode(), camera);
+			FillRenderList(quadtree->GetBackRightNode(), camera);
+			FillRenderList(quadtree->GetBackLeftNode(), camera);
 		}
 	}
 }
 
-void ModuleRender::AddToRenderList(const GameObject* gameObject)
+void ModuleRender::AddToRenderList(const GameObject* gameObject, Camera* camera, bool recursive)
 {
-	
-	Camera* camera = GetFrustumCheckedCamera();
-
 	float3 cameraPos = camera->GetPosition();
 
 	if (gameObject->GetParent() == nullptr)
@@ -888,19 +812,26 @@ void ModuleRender::AddToRenderList(const GameObject* gameObject)
 		ComponentMeshRenderer* mesh = gameObject->GetComponentInternal<ComponentMeshRenderer>();
 		if (gameObject->IsActive() && (mesh == nullptr || mesh->IsEnabled()))
 		{
-			const ComponentTransform* transform = gameObject->GetComponentInternal<ComponentTransform>();
-			float dist = Length(cameraPos - transform->GetGlobalPosition());
+			ComponentTransform* transform = gameObject->GetComponentInternal<ComponentTransform>();
 
-			gameObjectsInFrustrum.insert(gameObject);
-			objectsInFrustrumDistances[gameObject] = dist;
+			if (camera->IsInside(transform->GetEncapsuledAABB()))
+			{
+				if (gameObject->IsActive() && gameObject->IsEnabled())
+				{
+					float dist = Length(cameraPos - transform->GetGlobalPosition());
+
+					gameObjectsInFrustrum.insert(gameObject);
+					objectsInFrustrumDistances[gameObject] = dist;
+				}
+			}
 		}
 	}
 
-	if (!gameObject->GetChildren().empty())
+	if (recursive && !gameObject->GetChildren().empty())
 	{
 		for (GameObject* children : gameObject->GetChildren())
 		{
-			AddToRenderList(children);
+			AddToRenderList(children, camera, recursive);
 		}
 	}
 }
@@ -932,222 +863,6 @@ void ModuleRender::RelocateGOInBatches(GameObject* go)
 	batchManager->SwapBatchParentAndChildren(go);
 }
 
-float2 ModuleRender::ParallelReduction(Program* program, int width, int height)
-{
-	program->Activate();
-
-	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Parallel Reduction")),
-		"Parallel Reduction");
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, gBuffer->GetDepthTexture());
-
-	//Use the texture as an image
-	glBindImageTexture(0, parallelReductionInTexture, 0, false, 0, GL_WRITE_ONLY, GL_RG32F);
-
-	program->BindUniformInt2("inSize", width, height);
-
-	unsigned int numGroupsX = (width + (16 - 1)) / 16;
-	unsigned int numGroupsY = (height + (8 - 1)) / 8;
-
-	glDispatchCompute(numGroupsX, numGroupsY, 1);
-	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
-
-	GLuint srcTexture = parallelReductionInTexture; 
-	GLuint dstTexture = parallelReductionOutTexture;
-
-	while (numGroupsX > 1 || numGroupsY > 1)
-	{
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, srcTexture);
-
-		//Use the texture as an image
-		glBindImageTexture(0, dstTexture, 0, false, 0, GL_WRITE_ONLY, GL_RG32F);
-
-		program->BindUniformInt2("inSize", numGroupsX, numGroupsY);
-
-		numGroupsX = (numGroupsX + (8 - 1)) / 8;
-		numGroupsY = (numGroupsY + (4 - 1)) / 4;
-
-		glDispatchCompute(numGroupsX, numGroupsY, 1);
-		glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
-
-		std::swap(srcTexture, dstTexture);
-	}
-	
-	glPopDebugGroup();
-
-	program->Deactivate();
-
-	program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::MIN_MAX);
-
-	program->Activate();
-	
-	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Min Max")), "Min Max");
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, srcTexture);
-
-	float2 minMax(0.0f, 0.0f);
-
-	glBindBuffer(GL_SHADER_STORAGE_BUFFER, minMaxBuffer);
-	glBufferData(GL_SHADER_STORAGE_BUFFER, sizeof(minMax), &minMax[0], GL_DYNAMIC_DRAW);
-	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, minMaxBuffer);
-	glBindBuffer(GL_SHADER_STORAGE_BUFFER, 0);
-
-	glDispatchCompute(1, 1, 1);
-	glMemoryBarrier(GL_BUFFER_UPDATE_BARRIER_BIT);
-
-	glBindBuffer(GL_SHADER_STORAGE_BUFFER, minMaxBuffer);
-	glGetBufferSubData(GL_SHADER_STORAGE_BUFFER, 0, sizeof(minMax), &minMax[0]);
-
-	glPopDebugGroup();
-
-	program->Deactivate();
-
-	//glGetTextureSubImage(srcTexture, 0, 0, 0, 0, 1, 1, 1, GL_RG, GL_FLOAT, sizeof(float2), &minMax);
-
-	glBindTexture(GL_TEXTURE_2D, 0);
-
-	return minMax;
-}
-
-void ModuleRender::RenderShadowMap(const GameObject* light, const float2& minMax)
-{
-	// Get light position
-	const ComponentTransform* lightTransform = light->GetComponent<ComponentTransform>();
-	const float3& lightPos = lightTransform->GetGlobalPosition();
-
-	// Compute camera frustrum bounding sphere
-	math::Frustum* cameraFrustum = new Frustum(*App->GetModule<ModuleCamera>()->GetCamera()->GetFrustum());
-
-	// SDSM: Calculus for the final near an far planes
-	float n = cameraFrustum->NearPlaneDistance();
-	float f = cameraFrustum->FarPlaneDistance();
-	float T = -(n + f) / (f - n);
-	float S = (-2 * f * n) / (f - n);
-	float lightNear = S / (T + minMax[0]);
-	float lightFar = S / (T + minMax[1]);
-
-	if (lightNear > lightFar) {
-		lightNear = 0.1f;
-	}
-
-	cameraFrustum->SetViewPlaneDistances(lightNear, lightFar);
-
-	float3 corners[8];
-	cameraFrustum->GetCornerPoints(corners);
-
-	const float3 sphereCenter = cameraFrustum->CenterPoint();
-	float sphereRadius = 0.0f;
-
-	for (unsigned int i = 0; i < 8; ++i)
-	{
-		sphereRadius = std::max(sphereRadius, sphereCenter.Distance(corners[i]));
-	}
-
-	// Compute bounding box
-	math::Frustum frustum;
-
-	float3 lightFront = lightTransform->GetGlobalForward();
-	float3 lightRight = Cross(lightFront, float3(0.0f, 1.0f, 0.0f)).Normalized();
-	float3 lifghtUp = math::Cross(lightRight, lightFront).Normalized();
-	frustum.SetKind(FrustumProjectiveSpace::FrustumSpaceGL, FrustumHandedness::FrustumRightHanded);
-	frustum.SetPos(sphereCenter - lightFront * sphereRadius);
-	frustum.SetFront(lightFront);
-	frustum.SetUp(lifghtUp);
-	frustum.SetViewPlaneDistances(0.0f, sphereRadius * 2.0f);
-	frustum.SetOrthographic(sphereRadius * 2.0f, sphereRadius * 2.0f);
-
-	// Frustum culling with the created light frustum to obtain the meshes of the scene to take into account
-	std::vector<GameObject*> objectsInFrustum =
-		App->GetModule<ModuleScene>()->GetLoadedScene()->ObtainObjectsInFrustum(&frustum);
-
-	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, static_cast<GLsizei>(std::strlen("Shadow Mapping")), 
-		"Shadow Mapping");
-
-	// Program binding
-	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::SHADOW_MAPPING);
-	program->Activate();
-
-	glBindFramebuffer(GL_FRAMEBUFFER, shadowMapBuffer);
-	glClear(GL_DEPTH_BUFFER_BIT);
-
-	dirLightView = frustum.ViewMatrix();
-	dirLightProj = frustum.ProjectionMatrix();
-
-	glBindBuffer(GL_UNIFORM_BUFFER, uboCamera);
-	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float4) * 4, &dirLightProj[0]);
-	glBufferSubData(GL_UNIFORM_BUFFER, 64, sizeof(float4) * 4, &dirLightView[0]);
-	glBindBuffer(GL_UNIFORM_BUFFER, 0);
-
-	batchManager->DrawMeshes(objectsInFrustum, float3(frustum.Pos()));
-
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-	program->Deactivate();
-
-	glPopDebugGroup();
-}
-
-void ModuleRender::ShadowDepthVariacne(int width, int height)
-{
-	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::SHADOW_DEPTH_VARIANCE);
-
-	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, std::strlen("Shadow Depth Variance"), "Shadow Depth Variance");
-
-	program->Activate();
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, gShadowMap);
-
-	glBindImageTexture(0, shadowVarianceTexture, 0, false, 0, GL_WRITE_ONLY, GL_RG32F);
-
-	program->BindUniformInt2("inSize", width, height);
-
-	unsigned int numGroupsX = (width + (16 - 1)) / 16;
-	unsigned int numGroupsY = (height + (8 - 1)) / 8;
-
-	glDispatchCompute(numGroupsX, numGroupsY, 1);
-	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT);
-
-	program->Deactivate();
-
-	glPopDebugGroup();
-}
-
-void ModuleRender::GaussianBlur(int width, int height)
-{
-	Program* program = App->GetModule<ModuleProgram>()->GetProgram(ProgramType::GAUSSIAN_BLUR);
-
-	glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, std::strlen("Gaussian Blur"), "Gaussian Blur");
-
-	program->Activate();
-
-	glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[0]);
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, shadowVarianceTexture);
-
-	program->BindUniformFloat2("invSize", float2(1.0f / width, 1.0f / height));
-	program->BindUniformFloat2("blurDirection", float2(1.0f, 0.0f));
-
-	glDrawArrays(GL_TRIANGLES, 0, 3);
-
-	glBindFramebuffer(GL_FRAMEBUFFER, blurShadowMapBuffer[1]);
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, gBluredShadowMap[0]);
-
-	program->BindUniformFloat2("blurDirection", float2(0.0f, 1.0f));
-
-	glDrawArrays(GL_TRIANGLES, 0, 3);
-
-	program->Deactivate();
-
-	glPopDebugGroup();
-}
-
 void ModuleRender::DrawHighlight(GameObject* gameObject)
 {
 	std::queue<GameObject*> gameObjectQueue;
@@ -1176,13 +891,13 @@ void ModuleRender::DrawHighlight(GameObject* gameObject)
 	}
 }
 
-void ModuleRender::BindCameraToProgram(Program* program)
+void ModuleRender::BindCameraToProgram(Program* program, Camera* camera)
 {
 	program->Activate();
 
-	const float4x4& view = App->GetModule<ModuleCamera>()->GetCamera()->GetViewMatrix();
-	const float4x4& proj = App->GetModule<ModuleCamera>()->GetCamera()->GetProjectionMatrix();
-	float3 viewPos = App->GetModule<ModuleCamera>()->GetCamera()->GetPosition();
+	const float4x4& view = camera->GetFrustum()->ViewMatrix();
+	const float4x4& proj = camera->GetFrustum()->ProjectionMatrix();
+	float3 viewPos = camera->GetPosition();
 
 	glBindBuffer(GL_UNIFORM_BUFFER, uboCamera);
 	glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(float4) * 4, &proj);

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -337,7 +337,7 @@ UpdateStatus ModuleRender::Update()
 	{
 		// ---- PARALLEL REDUCTION ----
 		float2 minMax = shadows->ParallelReduction(gBuffer);
-		shadows->RenderShadowMap(loadedScene->GetDirectionalLight(), minMax, checkedCamera);
+		shadows->RenderShadowMap(loadedScene->GetDirectionalLight(), minMax, engineCamera);
 
 		if (shadows->UseVSM())
 		{
@@ -383,8 +383,11 @@ UpdateStatus ModuleRender::Update()
 		ComponentDirLight* directLight = static_cast<ComponentDirLight*>(
 			App->GetModule<ModuleScene>()->GetLoadedScene()->GetDirectionalLight()->GetComponent<ComponentLight>());
 
-		program->BindUniformFloat("minBias", directLight->shadowBias[0]);
-		program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
+		if (!shadows->UseVSM())
+		{
+			program->BindUniformFloat("minBias", directLight->shadowBias[0]);
+			program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
+		}
 	}
 	program->BindUniformInt("useShadows", static_cast<int>(shadows->UseShadows()));
 	program->BindUniformInt("useVSM", static_cast<int>(shadows->UseVSM()));

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -383,11 +383,8 @@ UpdateStatus ModuleRender::Update()
 		ComponentDirLight* directLight = static_cast<ComponentDirLight*>(
 			App->GetModule<ModuleScene>()->GetLoadedScene()->GetDirectionalLight()->GetComponent<ComponentLight>());
 
-		if (!shadows->UseVSM())
-		{
-			program->BindUniformFloat("minBias", directLight->shadowBias[0]);
-			program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
-		}
+		program->BindUniformFloat("minBias", directLight->shadowBias[0]);
+		program->BindUniformFloat("maxBias", directLight->shadowBias[1]);
 	}
 	program->BindUniformInt("useShadows", static_cast<int>(shadows->UseShadows()));
 	program->BindUniformInt("useVSM", static_cast<int>(shadows->UseVSM()));

--- a/Source/Modules/ModuleRender.h
+++ b/Source/Modules/ModuleRender.h
@@ -9,6 +9,8 @@
 
 #include "PostProcess/SSAO.h"
 
+#include "Render/Shadows.h"
+
 #define KAWASE_DUAL_SAMPLERS 4
 #define GAUSSIAN_BLUR_SHADOW_MAP 2
 
@@ -53,7 +55,9 @@ public:
 	void ToggleShadows();
 	void ToggleVSM();
 	void ToggleSSAO();
+	void ToggleCSMDebug();
 
+	GLuint GetCameraUBO() const;
 	GLuint GetRenderedTexture() const;
 	float GetObjectDistance(const GameObject* gameObject);
 
@@ -62,8 +66,8 @@ public:
 
 	BatchManager* GetBatchManager() const;
 
-	void FillRenderList(const Quadtree* quadtree);
-	void AddToRenderList(const GameObject* gameObject);
+	void FillRenderList(const Quadtree* quadtree, Camera* camera);
+	void AddToRenderList(const GameObject* gameObject, Camera* camera, bool recursive = false);
 
 	bool IsObjectInsideFrustrum(const GameObject* gameObject);
 
@@ -95,15 +99,10 @@ private:
 
 	void DrawHighlight(GameObject* gameObject);
 
-	void BindCameraToProgram(Program* program);
+	void BindCameraToProgram(Program* program, Camera* camera);
 	void BindCubemapToProgram(Program* program);
 
 	void KawaseDualFiltering();
-
-	float2 ParallelReduction(Program* program, int width, int height);
-	void RenderShadowMap(const GameObject* light, const float2& minMax);
-	void ShadowDepthVariacne(int width, int height);
-	void GaussianBlur(int width, int height);
 
 	Camera* GetFrustumCheckedCamera() const;
 
@@ -118,6 +117,7 @@ private:
 
 	BatchManager* batchManager;
 	GBuffer* gBuffer;
+	Shadows* shadows;
 	SSAO* ssao;
 
 	unsigned uboCamera;
@@ -140,25 +140,12 @@ private:
 	GLuint dualKawaseDownTextures[KAWASE_DUAL_SAMPLERS];
 	GLuint dualKawaseUpFramebuffers[KAWASE_DUAL_SAMPLERS];
 	GLuint dualKawaseUpTextures[KAWASE_DUAL_SAMPLERS];
+
+	GLuint depthStencilRenderBuffer = 0;
 	
 	//GLuint bloomFramebuffer;
 	//GLuint bloomTexture;
 	
-	// Shadow Mapping buffers and textures
-	GLuint depthStencilRenderBuffer = 0;
-	GLuint shadowMapBuffer = 0;
-	GLuint gShadowMap = 0;
-	GLuint parallelReductionInTexture = 0;
-	GLuint parallelReductionOutTexture = 0;
-	GLuint minMaxBuffer = 0;
-	
-	// Variance Shadow Mapping buffers and textures
-	GLuint shadowVarianceTexture = 0;
-	GLuint blurShadowMapBuffer[GAUSSIAN_BLUR_SHADOW_MAP];
-	GLuint gBluredShadowMap[GAUSSIAN_BLUR_SHADOW_MAP];
-
-	bool renderShadows;
-	bool varianceShadowMapping;
 
 	friend class ModuleEditor;
 };
@@ -190,17 +177,27 @@ inline void ModuleRender::SwitchBloomActivation()
 
 inline void ModuleRender::ToggleShadows()
 {
-	renderShadows = !renderShadows;
+	shadows->ToggleShadows();
 }
 
 inline void ModuleRender::ToggleVSM()
 {
-	varianceShadowMapping = !varianceShadowMapping;
+	shadows->ToggleVSM();
 }
 
 inline void ModuleRender::ToggleSSAO()
 {
 	ssao->ToggleSSAO();
+}
+
+inline void ModuleRender::ToggleCSMDebug()
+{
+	shadows->ToggleCSMDebug();
+}
+
+inline GLuint ModuleRender::GetCameraUBO() const
+{
+	return uboCamera;
 }
 
 inline GLuint ModuleRender::GetRenderedTexture() const

--- a/Source/Shaders/Common/Structs/cascade_light_matrices.glsl
+++ b/Source/Shaders/Common/Structs/cascade_light_matrices.glsl
@@ -1,0 +1,16 @@
+#ifndef _CASCADE_LIGHT_MATRICES_
+#define _CASCADE_LIGHT_MATRICES_
+
+layout(std140, row_major, binding = 2) uniform LightSpaceMatrices 
+{
+    mat4 proj[CASCADES];    // 16 // 00 (column 0)
+                            // 16 // 16 (column 1)
+                            // 16 // 32 (column 2)
+                            // 16 // 48 (column 3)
+    mat4 view[CASCADES];    // 16 // 64 (column 0)
+                            // 16 // 80 (column 1)
+                            // 16 // 96 (column 2)
+                            // 16 // 112 (column 3)
+};
+
+#endif

--- a/Source/Shaders/deferred_lighting_fragment.glsl
+++ b/Source/Shaders/deferred_lighting_fragment.glsl
@@ -1,23 +1,43 @@
 #version 460
 
 #extension GL_ARB_shading_language_include : require
+#extension GL_NV_uniform_buffer_std430_layout : enable
 
 #include "/Common/Functions/pbr_functions.glsl"
 
 #include "/Common/Structs/lights.glsl"
+
+#define CASCADES 3
 
 layout(binding = 0) uniform sampler2D gPosition;
 layout(binding = 1) uniform sampler2D gNormal;
 layout(binding = 2) uniform sampler2D gDiffuse;
 layout(binding = 3) uniform sampler2D gSpecular;
 layout(binding = 4) uniform sampler2D gEmissive;
-layout(binding = 5) uniform sampler2D gShadowMap;
+layout(binding = 5) uniform sampler2DArray gShadowMap;
 layout(binding = 6) uniform sampler2D gSSAO;
 
 layout(std140, binding=1) uniform Directional
 {
 	vec3 directionalDir;  	//12	//0
 	vec4 directionalColor;	//16	//16     // note: alpha parameter of colour is the intensity 
+};
+
+layout(std140, row_major, binding = 2) uniform LightSpaceMatrices 
+{
+    mat4 projMatrix[CASCADES];    // 16 // 00 (column 0)
+                                  // 16 // 16 (column 1)
+                                  // 16 // 32 (column 2)
+                                  // 16 // 48 (column 3)
+    mat4 viewMatrix[CASCADES];    // 16 // 64 (column 0)
+                                  // 16 // 80 (column 1)
+                                  // 16 // 96 (column 2)
+                                  // 16 // 112 (column 3)
+};
+
+layout(std430, binding = 3) uniform CascadePlaneDistances 
+{
+    float cascadePlaneDistances[CASCADES];
 };
 
 readonly layout(std430, binding=2) buffer PointLights
@@ -54,14 +74,15 @@ uniform float cubemap_intensity;
 uniform int renderMode;
 
 uniform vec3 viewPos;
+uniform mat4 cameraViewMatrix;
 
 // Shadow Mapping
-uniform mat4 lightSpaceMatrix;
 uniform float minBias;
 uniform float maxBias;
 uniform int useShadows;
 uniform int useVSM;
 uniform int useSSAO;
+uniform int toggleCSMDebug;
 
 in vec2 TexCoord;
 
@@ -275,31 +296,41 @@ vec3 calculateAreaLightTubes(vec3 N, vec3 V, vec3 Cd, vec3 f0, float roughness, 
     return Lo;
 }
 
-float ShadowCalculation(vec4 posFromLight, vec3 normal)
+float ShadowCalculation(vec4 posFromLight, vec3 normal, int layer)
 {
     // perform perspective divide
     vec3 projCoords = posFromLight.xyz / posFromLight.w;
     // transform to [0,1] range
     projCoords = projCoords * 0.5 + 0.5;
     // get closest depth value from light's perspective (using [0,1] range fragPosLight as coords)
-    float closestDepth = texture(gShadowMap, projCoords.xy).r; 
+    float closestDepth = texture(gShadowMap, vec3(projCoords.xy, layer)).r; 
     // get depth of current fragment from light's perspective
     float currentDepth = projCoords.z;
     // check whether current frag pos is in shadow
-    float bias = max(minBias * (1.0 - dot(normal, directionalDir)), maxBias);  
+    float bias = max(minBias * (1.0 - dot(normal, directionalDir)), maxBias);
+    // apply a different bias depending on which shadow map we sample from
+    if (layer == CASCADES)
+    {
+        bias *= 1 / (cascadePlaneDistances[CASCADES - 1] * 0.5f);
+    }
+    else
+    {
+        bias *= 1 / (cascadePlaneDistances[layer] * 0.5f);
+    }
+
     float shadow = currentDepth - bias > closestDepth ? 1.0 : 0.0;
 
     return shadow;
 }
 
-float ChebyshevUpperBound(vec4 posFromLight)
+float ChebyshevUpperBound(vec4 posFromLight, int layer)
 {
     // perform perspective divide
     vec3 projCoords = posFromLight.xyz / posFromLight.w;
     // transform to [0,1] range
     projCoords = projCoords * 0.5 + 0.5;
 	// We retrive the two moments previously stored (depth and depth*depth)
-	vec2 moments = texture2D(gShadowMap,projCoords.xy).rg;
+	vec2 moments = texture(gShadowMap, vec3(projCoords.xy, layer)).rg;
 		
 	// Surface is fully lit. as the current fragment is before the light occluder
 	if (projCoords.z <= moments.x)
@@ -338,17 +369,36 @@ void main()
 
         // Shadow Mapping
         float shadow = 1.0;
+        vec3 layerColor = vec3(0.0, 0.0, 0.0);
         if (useShadows > 0)
         {
-            vec4 fragPosFromLightSpace = lightSpaceMatrix*vec4(fragPos, 1.0);
+            vec4 fragPosViewSpace = cameraViewMatrix * vec4(fragPos, 1.0);
+            float depthValue = abs(fragPosViewSpace.z);
+    
+            int layer = -1;
+            for (int i = 0; i < CASCADES; ++i)
+            {
+                if (depthValue < cascadePlaneDistances[i])
+                {
+                    layer = i;
+                    layerColor[i] = 1.0;
+                    break;
+                }
+            }
+            if (layer == -1)
+            {
+                layer = CASCADES;
+            }
+    
+            vec4 fragPosFromLightSpace = projMatrix[layer] * viewMatrix[layer] * vec4(fragPos, 1.0);
 
             if (useVSM == 1)
             {
-                shadow = ChebyshevUpperBound(fragPosFromLightSpace);
+                shadow = ChebyshevUpperBound(fragPosFromLightSpace, layer);
             }
             else
             {
-                shadow = 1 - ShadowCalculation(fragPosFromLightSpace, norm);
+                shadow = 1 - ShadowCalculation(fragPosFromLightSpace, norm, layer);
             }            
         }
     
@@ -381,6 +431,7 @@ void main()
             environmentBRDF, numLevels_IBL) * cubemap_intensity;
 
         vec3 color = ambient + Lo + emissiveMat.rgb;
+        color += toggleCSMDebug == 1 ? layerColor : vec3(0.0, 0.0, 0.0);
         color = useSSAO == 1 ? color*texture(gSSAO, TexCoord).r : color;
         outColor = vec4(color, 1.0);
     }

--- a/Source/Shaders/deferred_lighting_fragment.glsl
+++ b/Source/Shaders/deferred_lighting_fragment.glsl
@@ -7,7 +7,7 @@
 
 #include "/Common/Structs/lights.glsl"
 
-#define CASCADES 3
+#define CASCADES 2
 
 layout(binding = 0) uniform sampler2D gPosition;
 layout(binding = 1) uniform sampler2D gNormal;

--- a/Source/Shaders/gaussian_blur_3d_fragment.glsl
+++ b/Source/Shaders/gaussian_blur_3d_fragment.glsl
@@ -1,0 +1,33 @@
+#version 460
+
+layout(binding = 0) uniform sampler2DArray sourceTexture;
+uniform vec2 invSize;
+uniform vec2 blurDirection;
+
+in vec2 TexCoord;
+out vec4 color;
+
+const int SAMPLE_COUNT = 3;
+const float OFFSETS[3] = float[3](
+    -1.4990620619239194,
+    0.4996866407382734,
+    2
+);
+
+const float WEIGHTS[3] = float[3](
+    0.3997495607369067,
+    0.4007505992285515,
+    0.19949984003454174
+);
+
+void main()
+{
+	vec4 result = vec4(0.0);
+
+	for (int i = 0; i < SAMPLE_COUNT; ++i)
+	{
+		result += texture(sourceTexture, vec3(TexCoord + blurDirection * OFFSETS[i] * invSize, gl_Layer)) * WEIGHTS[i];
+	}
+
+	color = vec4(result.rgb, 1.0);
+}

--- a/Source/Shaders/gaussian_blur_3d_geometry.glsl
+++ b/Source/Shaders/gaussian_blur_3d_geometry.glsl
@@ -1,0 +1,24 @@
+#version 460 core
+   
+#define CASCADES 3
+
+layout(triangles, invocations = CASCADES) in;
+layout(triangle_strip, max_vertices = 3) out;
+
+in VS_OUT {
+    vec2 texCoord;
+} gs_in[]; 
+
+out vec2 TexCoord;
+    
+void main()
+{          
+    for (int i = 0; i < 3; ++i)
+    {
+        TexCoord = gs_in[i].texCoord;
+        gl_Position = gl_in[i].gl_Position;
+        gl_Layer = gl_InvocationID;
+        EmitVertex();
+    }
+    EndPrimitive();
+} 

--- a/Source/Shaders/gaussian_blur_3d_geometry.glsl
+++ b/Source/Shaders/gaussian_blur_3d_geometry.glsl
@@ -1,6 +1,6 @@
 #version 460 core
    
-#define CASCADES 3
+#define CASCADES 2
 
 layout(triangles, invocations = CASCADES) in;
 layout(triangle_strip, max_vertices = 3) out;

--- a/Source/Shaders/render_clip_space_vertex_3d.glsl
+++ b/Source/Shaders/render_clip_space_vertex_3d.glsl
@@ -1,0 +1,16 @@
+#version 460
+
+out VS_OUT {
+    vec2 texCoord;
+} vs_out;
+ 
+void main()
+{
+    float x = -1.0 + float((gl_VertexID & 1) << 2);
+    float y = -1.0 + float((gl_VertexID & 2) << 1);
+
+    vs_out.texCoord.x = (x + 1.0) * 0.5;
+    vs_out.texCoord.y = (y + 1.0) * 0.5;
+    
+    gl_Position = vec4(x, y, 0.0, 1.0);
+}

--- a/Source/Shaders/shadow_depth_variance.glsl
+++ b/Source/Shaders/shadow_depth_variance.glsl
@@ -1,8 +1,9 @@
 #version 460
 
-layout(binding = 0) uniform sampler2D inTexture;
+layout(binding = 0) uniform sampler2DArray inTexture;
+uniform int cascadeCount;
 
-uniform layout(binding=0, rg32f) writeonly image2D outImage;
+uniform layout(binding=0, rg32f) writeonly image2DArray outImage;
 uniform ivec2 inSize;
 
 layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;
@@ -13,9 +14,11 @@ void main()
 	{
 		ivec2 inCoord = ivec2(gl_GlobalInvocationID.xy);
 
-		float depth = texelFetch(inTexture, inCoord, 0).r;
-		float sqdDepth = depth*depth; 
-
-		imageStore(outImage, inCoord, vec4(depth, sqdDepth, 0.0, 1.0));
+		for (unsigned int i = 0; i < cascadeCount; ++i)
+		{
+			float depth = texelFetch(inTexture, ivec3(inCoord, i), 0).r;
+			float sqdDepth = depth*depth;
+			imageStore(outImage, ivec3(inCoord, i), vec4(depth, sqdDepth, 0.0, 1.0));
+		}
 	}
 }

--- a/Source/Shaders/shadow_map_geometry.glsl
+++ b/Source/Shaders/shadow_map_geometry.glsl
@@ -1,0 +1,30 @@
+#version 460 core
+   
+#define CASCADES 3
+
+layout(triangles, invocations = CASCADES) in;
+layout(triangle_strip, max_vertices = 3) out;
+    
+layout(std140, row_major, binding = 2) uniform LightSpaceMatrices 
+{
+    mat4 proj[CASCADES];    // 16 // 00 (column 0)
+                            // 16 // 16 (column 1)
+                            // 16 // 32 (column 2)
+                            // 16 // 48 (column 3)
+    mat4 view[CASCADES];    // 16 // 64 (column 0)
+                            // 16 // 80 (column 1)
+                            // 16 // 96 (column 2)
+                            // 16 // 112 (column 3)
+};
+    
+void main()
+{          
+    for (int i = 0; i < 3; ++i)
+    {
+        gl_Position = 
+            proj[gl_InvocationID] * view[gl_InvocationID] * gl_in[i].gl_Position;
+        gl_Layer = gl_InvocationID;
+        EmitVertex();
+    }
+    EndPrimitive();
+} 

--- a/Source/Shaders/shadow_map_geometry.glsl
+++ b/Source/Shaders/shadow_map_geometry.glsl
@@ -1,6 +1,6 @@
 #version 460 core
    
-#define CASCADES 3
+#define CASCADES 2
 
 layout(triangles, invocations = CASCADES) in;
 layout(triangle_strip, max_vertices = 3) out;

--- a/Source/Shaders/shadow_map_vertex.glsl
+++ b/Source/Shaders/shadow_map_vertex.glsl
@@ -6,18 +6,6 @@ struct PerInstance {
     uint  padding0, padding1;
 };
 
-layout(std140, row_major, binding = 0) uniform Camera 
-{
-    mat4 proj;      // 16 // 00 (column 0)
-                    // 16 // 16 (column 1)
-                    // 16 // 32 (column 2)
-                    // 16 // 48 (column 3)
-    mat4 view;      // 16 // 64 (column 0)
-                    // 16 // 80 (column 1)
-                    // 16 // 96 (column 2)
-                    // 16 // 112 (column 3)
-};
-
 layout(std430, row_major, binding = 7) buffer Skinning
 {
     mat4 palette[];
@@ -59,5 +47,5 @@ void main()
         norm  = (skinT*vec4(normal, 0.0));
     }
 
-    gl_Position = proj*view*model*position;
+    gl_Position = model*position;
 }


### PR DESCRIPTION
Implemented cascade shadow maps in order to improve shadow resolution in large scenes.

**Use F7 in order to enable CSM debugging and see the different view frustums**

|Whitout CSM|With CSM|
|----|----|
|![SM_VSM](https://github.com/Horizons-Games/Axolotl-Engine/assets/18547655/70659b88-05af-415e-aef3-f14b708d84a4)|![CSM_withVSM](https://github.com/Horizons-Games/Axolotl-Engine/assets/18547655/ea2d8480-9c3c-4239-86ab-2c3d0f80c019)|