### PR TITLE
feat: Elevator behaviour

### DIFF
--- a/Game/Scripts/ActivationLogic.cpp
+++ b/Game/Scripts/ActivationLogic.cpp
@@ -18,6 +18,7 @@
 
 #include "../Scripts/CameraControllerScript.h"
 #include "../Scripts/PlayerManagerScript.h"
+#include "../Scripts/HackZoneScript.h"
 
 #include "DataStructures/Quadtree.h"
 #include "Auxiliar/Audio/AudioData.h"
@@ -27,6 +28,7 @@ REGISTERCLASS(ActivationLogic);
 ActivationLogic::ActivationLogic() : Script(),
 componentAudio(nullptr), activeState(ActiveActions::INACTIVE)
 {
+	REGISTER_FIELD(linkedHackZone, HackZoneScript*);
 }
 
 ActivationLogic::~ActivationLogic()
@@ -60,6 +62,11 @@ void ActivationLogic::Update(float deltaTime)
 
 void ActivationLogic::OnCollisionEnter(ComponentRigidBody* other)
 {
+	if (linkedHackZone && !linkedHackZone->IsCompleted())
+	{
+		return;
+	}
+
 	if (!App->GetModule<ModulePlayer>()->GetCameraPlayerObject()->GetComponent<CameraControllerScript>()->IsInCombat())
 	{
 		if (other->GetOwner()->CompareTag("Player"))

--- a/Game/Scripts/ActivationLogic.h
+++ b/Game/Scripts/ActivationLogic.h
@@ -11,6 +11,8 @@ class ComponentAudioSource;
 class ComponentAnimation;
 class ComponentRigidBody;
 
+class HackZoneScript;
+
 // Little fix until we could check if an audio is being reproduced
 enum class ActiveActions
 {
@@ -36,4 +38,6 @@ private:
 	ComponentAnimation* componentAnimation;
 	ActiveActions activeState;
 	ComponentRigidBody* componentRigidBody;
+
+	HackZoneScript* linkedHackZone;
 };

--- a/Game/Scripts/ElevatorCore.cpp
+++ b/Game/Scripts/ElevatorCore.cpp
@@ -108,7 +108,6 @@ void ElevatorCore::Update(float deltaTime)
 			positionState = PositionState::DOWN;
 			activeState = ActiveActions::INACTIVE;
 			currentTime = coolDown;
-			LOG_DEBUG("Cool Down of {} seconds started", currentTime);
 			EnableAllInteractions();
 		}
 		
@@ -117,7 +116,6 @@ void ElevatorCore::Update(float deltaTime)
 			positionState = PositionState::UP;
 			activeState = ActiveActions::INACTIVE;
 			currentTime = coolDown;
-			LOG_DEBUG("Cool Down of {} seconds started", currentTime);
 			EnableAllInteractions();
 		}
 	}
@@ -127,7 +125,6 @@ void ElevatorCore::Update(float deltaTime)
 		if (currentTime >= 0)
 		{
 			currentTime -= deltaTime;
-			LOG_DEBUG("Cool Down of {} seconds continues", currentTime);
 		}
 
 	}

--- a/Game/Scripts/ElevatorCore.cpp
+++ b/Game/Scripts/ElevatorCore.cpp
@@ -33,6 +33,7 @@ componentAudio(nullptr), activeState(ActiveActions::INACTIVE), positionState(Pos
 	REGISTER_FIELD(elevator, GameObject*);
 	REGISTER_FIELD(finalPos, float);
 	REGISTER_FIELD(coolDown, float);
+	REGISTER_FIELD(speed, float);
 }
 
 ElevatorCore::~ElevatorCore()
@@ -73,11 +74,11 @@ void ElevatorCore::Update(float deltaTime)
 	{
 		if (positionState == PositionState::UP)
 		{
-			MoveDownElevator(true);
+			MoveDownElevator(true, deltaTime);
 		}
 		else 
 		{
-			MoveUpElevator(true);
+			MoveUpElevator(true, deltaTime);
 		}
 	}
 
@@ -85,11 +86,11 @@ void ElevatorCore::Update(float deltaTime)
 	{
 		if (positionState == PositionState::UP)
 		{
-			MoveDownElevator(false);
+			MoveDownElevator(false, deltaTime);
 		}
 		else
 		{
-			MoveUpElevator(false);
+			MoveUpElevator(false, deltaTime);
 		}
 	}
 
@@ -119,13 +120,13 @@ void ElevatorCore::Update(float deltaTime)
 	}
 }
 
-void ElevatorCore::MoveUpElevator(bool isPlayerInside)
+void ElevatorCore::MoveUpElevator(bool isPlayerInside, float deltaTime)
 {
 	float3 pos = transform->GetGlobalPosition();
 	btVector3 triggerOrigin = triggerEntrance->GetRigidBodyOrigin();
 
-	pos.y += 0.1f;
-	float newYTrigger = triggerOrigin.getY() + 0.1f;
+	pos.y += deltaTime * speed;
+	float newYTrigger = triggerOrigin.getY() + deltaTime * speed;
 	triggerOrigin.setY(newYTrigger);
 
 	transform->SetGlobalPosition(pos);
@@ -149,7 +150,7 @@ void ElevatorCore::MoveUpElevator(bool isPlayerInside)
 	if (isPlayerInside)
 	{
 		float3 playerPos = playerTransform->GetGlobalPosition();
-		playerPos.y += 0.1f;
+		playerPos.y += deltaTime * speed;
 
 		playerTransform->SetGlobalPosition(playerPos);
 		playerTransform->RecalculateLocalMatrix();
@@ -160,14 +161,14 @@ void ElevatorCore::MoveUpElevator(bool isPlayerInside)
 
 }
 
-void ElevatorCore::MoveDownElevator(bool isPlayerInside)
+void ElevatorCore::MoveDownElevator(bool isPlayerInside, float deltaTime)
 {
 	float3 pos = transform->GetGlobalPosition();
 	float3 playerPos = playerTransform->GetGlobalPosition();
 	btVector3 triggerOrigin = triggerEntrance->GetRigidBodyOrigin();
 
-	pos.y -= 0.1f;
-	float newYTrigger = triggerOrigin.getY() - 0.1f;
+	pos.y -= deltaTime * speed;
+	float newYTrigger = triggerOrigin.getY() - deltaTime * speed;
 	triggerOrigin.setY(newYTrigger);
 
 	transform->SetGlobalPosition(pos);
@@ -191,7 +192,7 @@ void ElevatorCore::MoveDownElevator(bool isPlayerInside)
 	if (isPlayerInside)
 	{
 		float3 playerPos = playerTransform->GetGlobalPosition();
-		playerPos.y -= 0.1f;
+		playerPos.y -= deltaTime * speed;
 
 		playerTransform->SetGlobalPosition(playerPos);
 		playerTransform->RecalculateLocalMatrix();

--- a/Game/Scripts/ElevatorCore.h
+++ b/Game/Scripts/ElevatorCore.h
@@ -15,7 +15,8 @@ class GameObject;
 // Little fix until we could check if an audio is being reproduced
 enum class ActiveActions
 {
-	ACTIVE,
+	ACTIVE_PLAYER,
+	ACTIVE_AUTO,
 	INACTIVE
 };
 
@@ -34,6 +35,8 @@ public:
 
 	void Start() override;
 	void Update(float deltaTime) override;
+	void MoveUpElevator(bool isPlayerInside);
+	void MoveDownElevator(bool isPlayerInside);
 	void OnCollisionEnter(ComponentRigidBody* other) override;
 	void OnCollisionExit(ComponentRigidBody* other) override;
 	void DisableAllInteractions();

--- a/Game/Scripts/ElevatorCore.h
+++ b/Game/Scripts/ElevatorCore.h
@@ -55,4 +55,7 @@ private:
 	GameObject* elevator;
 	float finalPos;
 	float finalUpPos;
+
+	float coolDown;
+	float currentTime;
 };

--- a/Game/Scripts/ElevatorCore.h
+++ b/Game/Scripts/ElevatorCore.h
@@ -12,6 +12,8 @@ class ComponentRigidBody;
 class ComponentTransform;
 class GameObject;
 
+class HealthSystem;
+
 // Little fix until we could check if an audio is being reproduced
 enum class ActiveActions
 {
@@ -63,4 +65,8 @@ private:
 	float currentTime;
 
 	float speed;
+
+
+	//Enemy condition
+	HealthSystem* miniBossHealth;
 };

--- a/Game/Scripts/ElevatorCore.h
+++ b/Game/Scripts/ElevatorCore.h
@@ -35,8 +35,8 @@ public:
 
 	void Start() override;
 	void Update(float deltaTime) override;
-	void MoveUpElevator(bool isPlayerInside);
-	void MoveDownElevator(bool isPlayerInside);
+	void MoveUpElevator(bool isPlayerInside, float deltaTime);
+	void MoveDownElevator(bool isPlayerInside, float deltaTime);
 	void OnCollisionEnter(ComponentRigidBody* other) override;
 	void OnCollisionExit(ComponentRigidBody* other) override;
 	void DisableAllInteractions();
@@ -61,4 +61,6 @@ private:
 
 	float coolDown;
 	float currentTime;
+
+	float speed;
 };


### PR DESCRIPTION
- Activation Logic has an option for taking the hacking into account.
- Elevator front doors linked with the hacking completion.
- Added a cooldown to the elevator in order to prevent infinite loop up and down.
- Elevator goes up when the player is going to face the miniboss.
- Elevator goes down when the miniboss is defeated.

For testing:
- Attach miniboss GameObject to the ElevatorCore script, and custom the cooldown and the elevator speed.