### PR TITLE
fix: Mesh Effect bugs

### DIFF
--- a/Game/Scripts/EnemyDeathScript.cpp
+++ b/Game/Scripts/EnemyDeathScript.cpp
@@ -15,6 +15,8 @@
 #include "../Scripts/PowerUpLogicScript.h"
 #include "../Scripts/CameraControllerScript.h"
 #include "../Scripts/FinalBossScript.h"
+#include "../Scripts/MeshEffect.h"
+#include "../Scripts/HealthSystem.h"
 
 REGISTERCLASS(EnemyDeathScript);
 
@@ -96,6 +98,9 @@ GameObject* EnemyDeathScript::RequestPowerUp() const
 
 void EnemyDeathScript::DisableEnemyActions()
 {
+	MeshEffect* meshEffectScript = owner->GetComponent<HealthSystem>()->GetMeshEffect();
+	meshEffectScript->ClearEffect();
+
 	// Once the enemy is dead, disable its scripts
 	std::vector<ComponentScript*> gameObjectScripts = owner->GetComponents<ComponentScript>();
 

--- a/Game/Scripts/HealthSystem.cpp
+++ b/Game/Scripts/HealthSystem.cpp
@@ -16,8 +16,8 @@
 
 REGISTERCLASS(HealthSystem);
 
-#define TIME_BETWEEN_EFFECTS 0.05f
-#define MAX_TIME_EFFECT_DURATION 0.1f
+#define TIME_BETWEEN_EFFECTS 0.10f
+#define MAX_TIME_EFFECT_DURATION 0.15f
 
 HealthSystem::HealthSystem() : Script(), currentHealth(100), maxHealth(100), componentAnimation(nullptr), 
 	isImmortal(false), enemyParticleSystem(nullptr), attackScript(nullptr),	damageTaken(false), playerManager(nullptr)

--- a/Game/Scripts/HealthSystem.cpp
+++ b/Game/Scripts/HealthSystem.cpp
@@ -12,7 +12,7 @@
 #include "../Scripts/PlayerDeathScript.h"
 #include "../Scripts/EnemyDeathScript.h"
 #include "../Scripts/PlayerManagerScript.h"
-#include "MeshEffect.h"
+#include "../Scripts/MeshEffect.h"
 
 REGISTERCLASS(HealthSystem);
 
@@ -174,4 +174,9 @@ void HealthSystem::SetDeathCallback(std::function<void(void)>&& callDeath)
 float HealthSystem::GetCurrentHealth() const
 {
 	return currentHealth;
+}
+
+MeshEffect* HealthSystem::GetMeshEffect() const
+{
+	return meshEffect;
 }

--- a/Game/Scripts/HealthSystem.h
+++ b/Game/Scripts/HealthSystem.h
@@ -34,6 +34,8 @@ public:
 	
 	void SetDeathCallback(std::function<void(void)>&& callDeath);
 
+	MeshEffect* GetMeshEffect() const;
+
 private:
 
 	float currentHealth;

--- a/Game/Scripts/PlayerDeathScript.cpp
+++ b/Game/Scripts/PlayerDeathScript.cpp
@@ -12,6 +12,9 @@
 #include "Components/ComponentAudioSource.h"
 #include "Components/ComponentRigidBody.h"
 
+#include "../Scripts/MeshEffect.h"
+#include "../Scripts/HealthSystem.h"
+
 #include "Auxiliar/Audio/AudioData.h"
 
 REGISTERCLASS(PlayerDeathScript);
@@ -48,6 +51,9 @@ void PlayerDeathScript::ManagePlayerDeath() const
 
 void PlayerDeathScript::DisablePlayerActions() const
 {
+	MeshEffect* meshEffectScript = owner->GetComponent<HealthSystem>()->GetMeshEffect();
+	meshEffectScript->ClearEffect();
+
 	// Once the player is dead, disable its scripts
 	std::vector<ComponentScript*> gameObjectScripts = owner->GetComponents<ComponentScript>();
 


### PR DESCRIPTION
The aim of this pr is to fix two bugs related to the mesh effect, and after talking with @PaablooCH, who originally designed and developed the mesh effect, we arrived to the following conclusions:

- The first bug was that, when you defeated an enemy, sometimes they turned invisible before despawning. This could be because, once an enemy is dead, all their scripts get deactivated (including the `HealthScript` that manages the mesh effect activation and deactivation) and the `ClearEffect()` fuction was sometimes not called, so that got swapped to the `EnemyDeathActions` script, ensuring that the effect will always get cleared before dying.
- The second bug was that Bix/Allura were not displaying correctly the effect sometimes, and after seeing that this does not happen in the test scenes (I've been looking at Bix taking damage for 20 minutes straight and the effect always worked), we thought that it could be related to the effect duration, as it was so brief that sometimes due to low fps it didn't got shown or updated correctly, so increasing the duration is the only solution we have for now.

As those two are bugs that happen sometimes, I can't assure you 100% that they are fixed, I've tried running the game a handful of times after fixing both bugs and everything seems fine, but if you still watch them happening please lmk and I see if there could be another thing causing any of the two bugs above, thanks!