### PR TITLE
fix[Scheduler]: prevent empty tasks from running

### DIFF
--- a/Source/Scheduler.cpp
+++ b/Source/Scheduler.cpp
@@ -29,7 +29,17 @@ void Scheduler::RunTasks()
 	while (!scheduledTasks.empty())
 	{
 		const Schedulable& task = scheduledTasks.front();
-		task();
+		if (task)
+		{
+			task();
+		}
+		else
+		{
+			// Error, because ScheduleTask should prevent this
+			// If this becomes too frequent we could index/ID the tasks and also log that index
+			// So we can see who schedules it
+			LOG_ERROR("Trying to run an empty task!");
+		}
 		scheduledTasks.pop();
 	}
 }


### PR DESCRIPTION
Not really sure why this happens or if it's an actual issue (ran into it while attempting to force a crash elsewhere), but more prottection never hurt.