### PR TITLE
fix[ModuleScene]: schedule script calls to load scene

### DIFF
--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -90,7 +90,7 @@ bool ModuleScene::Start()
 		std::string startingScene = startConfig["StartingScene"];
 		std::string scenePath = LIB_PATH "Scenes/" + startingScene;
 		assert(fileSystem->Exists(scenePath.c_str()));
-		LoadScene(scenePath, false);
+		LoadScene(scenePath, false, false);
 #endif
 	}
 	selectedGameObject = loadedScene->GetRoot();
@@ -339,16 +339,32 @@ void ModuleScene::SaveSceneToJson(Json& jsonScene)
 
 }
 
-void ModuleScene::LoadScene(const std::string& filePath, bool mantainActualScene)
+void ModuleScene::LoadScene(const std::string& name, bool mantainScene /*= false*/)
 {
-	loader::LoadScene(
-		filePath,
-		[]
-		{
-			// empty callback
-		},
-		mantainActualScene,
-		loader::LoadMode::BLOCKING);
+	LoadScene(name, mantainScene, true);
+}
+
+void ModuleScene::LoadScene(const std::string& name, bool mantainScene, bool scheduleLoad)
+{
+	auto loadLambda = [=]()
+	{
+		loader::LoadScene(
+			name,
+			[]
+			{
+				// empty callback
+			},
+			mantainScene,
+			loader::LoadMode::BLOCKING);
+	};
+	if (scheduleLoad)
+	{
+		App->ScheduleTask(std::move(loadLambda));
+	}
+	else
+	{
+		loadLambda();
+	}
 }
 
 void ModuleScene::LoadSceneAsync(const std::string& name, std::function<void(void)>&& callback, bool mantainCurrentScene)

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -60,6 +60,8 @@ private:
 
 	void SaveSceneToJson(Json& jsonScene);
 
+	void LoadScene(const std::string& name, bool mantainScene, bool scheduleLoad);
+
 private:
 	std::unique_ptr<Scene> loadedScene;
 	GameObject* selectedGameObject;


### PR DESCRIPTION
Hidden in a private function so users can't request their scene load to run in-place, which was the cause of the error and would never work.