### PR TITLE
fix: load scenes without skybox

### DIFF
--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -955,7 +955,7 @@ void ModuleRender::BindCubemapToProgram(Program* program)
 	ComponentSkybox* sky = App->GetModule<ModuleScene>()->GetLoadedScene()
 		->GetRoot()->GetComponentInternal<ComponentSkybox>();
 
-	if (sky->GetUseCubeMap())
+	if (sky && sky->GetUseCubeMap())
 	{
 		Cubemap* skyCubemap = sky->GetCubemap();
 		glActiveTexture(GL_TEXTURE8);


### PR DESCRIPTION
Scenes that did not have skybox (such as the trial scenes) couldn't be load after the skybox pr merge, this fixes it!