### PR TITLE
fix: Hacking while switching players

### DIFF
--- a/Game/Scripts/PlayerHackingUseScript.cpp
+++ b/Game/Scripts/PlayerHackingUseScript.cpp
@@ -50,7 +50,7 @@ void PlayerHackingUseScript::Update(float deltaTime)
 	if (input->GetKey(SDL_SCANCODE_E) == KeyState::DOWN && !isHackingActive && !isJumping && !isAttacking)
 	{
 		FindHackZone(hackingTag);
-		if (hackZone && !hackZone->IsCompleted())
+		if (hackZone && !hackZone->IsCompleted() && !playerManager->IsParalyzed())
 		{
 			InitHack();
 			isHackingButtonPressed = true;

--- a/Game/Scripts/PlayerManagerScript.cpp
+++ b/Game/Scripts/PlayerManagerScript.cpp
@@ -54,6 +54,11 @@ bool PlayerManagerScript::IsTeleporting() const
 	return false; // If no debug, then no tp is possible
 }
 
+bool PlayerManagerScript::IsParalyzed() const
+{
+	return movementManager->IsParalyzed();
+}
+
 float PlayerManagerScript::GetPlayerAttack() const
 {
 	return playerAttack;

--- a/Game/Scripts/PlayerManagerScript.h
+++ b/Game/Scripts/PlayerManagerScript.h
@@ -47,6 +47,7 @@ public:
 
 	bool IsGrounded() const;
 	bool IsTeleporting() const;
+	bool IsParalyzed() const;
 	PlayerJumpScript* GetJumpManager() const;
 	PlayerMoveScript* GetMovementManager() const;
 	PlayerAttackScript* GetAttackManager() const;


### PR DESCRIPTION
Solved an issue that allowed player to enable the hacking while Allura had been spawning (allowing the player to be not paralyzed while hacking)