### PR TITLE
fix[SceneLoad]: fixed memory leak in load scene async

### DIFF
--- a/Source/Auxiliar/SceneLoader.cpp
+++ b/Source/Auxiliar/SceneLoader.cpp
@@ -484,20 +484,20 @@ void LoadScene(std::variant<std::string, std::reference_wrapper<rapidjson::Docum
 		currentLoadingConfig->doc = std::get<std::reference_wrapper<rapidjson::Document>>(sceneNameOrDocument);
 	}
 
-	//if (currentLoadingConfig->loadMode == LoadMode::ASYNCHRONOUS)
-	//{
-	//	// Make sure the load starts at the end of the frame
-	//	App->ScheduleTask(
-	//		[]
-	//		{
-	//			std::thread startLoadThread = std::thread(&StartLoadScene);
-	//			startLoadThread.detach();
-	//		});
-	//}
-	//else
-	//{
-	StartLoadScene();
-	//}
+	if (currentLoadingConfig->loadMode == LoadMode::ASYNCHRONOUS)
+	{
+		// Make sure the load starts at the end of the frame
+		App->ScheduleTask(
+			[]
+			{
+				std::thread startLoadThread = std::thread(&StartLoadScene);
+				startLoadThread.detach();
+			});
+	}
+	else
+	{
+		StartLoadScene();
+	}
 }
 
 bool IsLoading()

--- a/Source/Auxiliar/SceneLoader.cpp
+++ b/Source/Auxiliar/SceneLoader.cpp
@@ -3,7 +3,10 @@
 #include "SceneLoader.h"
 
 #include "Application.h"
+
 #include "FileSystem/ModuleFileSystem.h"
+#include "FileSystem/ModuleResources.h"
+
 #include "Modules/ModuleEditor.h"
 #include "Modules/ModulePlayer.h"
 #include "Modules/ModuleRender.h"
@@ -416,7 +419,6 @@ void StartJsonLoad(Json&& sceneJson)
 
 void StartLoadScene()
 {
-	
 	ModuleRender* moduleRender = App->GetModule<ModuleRender>();
 	ModuleFileSystem* fileSystem = App->GetModule<ModuleFileSystem>();
 	ModuleUI* ui = App->GetModule<ModuleUI>();
@@ -492,20 +494,20 @@ void LoadScene(std::variant<std::string, std::reference_wrapper<rapidjson::Docum
 		currentLoadingConfig->doc = std::get<std::reference_wrapper<rapidjson::Document>>(sceneNameOrDocument);
 	}
 
-	if (currentLoadingConfig->loadMode == LoadMode::ASYNCHRONOUS)
-	{
-		// Make sure the load starts at the end of the frame
-		App->ScheduleTask(
-			[]
-			{
-				std::thread startLoadThread = std::thread(&StartLoadScene);
-				startLoadThread.detach();
-			});
-	}
-	else
-	{
-		StartLoadScene();
-	}
+	//if (currentLoadingConfig->loadMode == LoadMode::ASYNCHRONOUS)
+	//{
+	//	// Make sure the load starts at the end of the frame
+	//	App->ScheduleTask(
+	//		[]
+	//		{
+	//			std::thread startLoadThread = std::thread(&StartLoadScene);
+	//			startLoadThread.detach();
+	//		});
+	//}
+	//else
+	//{
+	StartLoadScene();
+	//}
 }
 
 bool IsLoading()

--- a/Source/DataModels/Batch/GeometryBatch.cpp
+++ b/Source/DataModels/Batch/GeometryBatch.cpp
@@ -74,6 +74,7 @@ GeometryBatch::~GeometryBatch()
 		}
 	}
 	componentsInBatch.clear();
+	resourcesMaterial.clear();
 
 	objectIndexes.clear();
 	instanceData.clear();

--- a/Source/DataModels/Resources/ResourceTexture.cpp
+++ b/Source/DataModels/Resources/ResourceTexture.cpp
@@ -31,6 +31,13 @@ void ResourceTexture::InternalUnload()
 {
 	glMakeTextureHandleNonResidentARB(handle);
 	glDeleteTextures(1, &glTexture);
+
+	// check OpenGL error
+	GLenum error = glGetError();
+	if (error != GL_NO_ERROR) {
+		SDL_assert(SDL_FALSE && "Problem with texture delete");
+	}
+
 	glTexture = 0;
 }
 
@@ -66,6 +73,11 @@ void ResourceTexture::LoadLoadOptions(Json& meta)
 
 void ResourceTexture::CreateTexture()
 {
+	if (glTexture != 0)
+	{
+		return;
+	}
+
 	glGenTextures(1, &glTexture);
 	glBindTexture(GL_TEXTURE_2D, glTexture);
 

--- a/Source/FileSystem/ModuleResources.cpp
+++ b/Source/FileSystem/ModuleResources.cpp
@@ -37,6 +37,7 @@ ModuleResources::ModuleResources() : monitorResources(false)
 
 ModuleResources::~ModuleResources()
 {
+	CleanUp();
 }
 
 bool ModuleResources::Init()
@@ -65,12 +66,28 @@ bool ModuleResources::CleanUp()
 {
 #ifdef ENGINE
 	monitorResources = false;
-	monitorThread.join();
+
+	if (monitorThread.joinable())
+	{
+		monitorThread.join();
+	}
 #else
 	resourcesBin.clear();
 #endif
 	resources.clear();
 	return true;
+}
+
+void ModuleResources::CleanResourceBin()
+{
+#ifndef ENGINE
+	resourcesBin.clear();
+#endif //! ENGINE
+}
+
+void ModuleResources::CleanResources()
+{
+	resources.clear();
 }
 
 void ModuleResources::CreateDefaultResource(ResourceType type, const std::string& fileName)

--- a/Source/FileSystem/ModuleResources.h
+++ b/Source/FileSystem/ModuleResources.h
@@ -54,6 +54,7 @@ public:
 
 	void FillResourceBin(std::shared_ptr<Resource> sharedResource);
 	void CleanResourceBin();
+	void CleanResources();
 
 private:
 	// resource creation and deletition
@@ -215,13 +216,6 @@ const std::shared_ptr<R> ModuleResources::RequestResource(const std::string path
 		}
 	}
 	return nullptr;
-}
-
-inline void ModuleResources::CleanResourceBin()
-{
-#ifndef ENGINE
-	resourcesBin.clear();
-#endif //! ENGINE
 }
 
 template<class R>


### PR DESCRIPTION
Loading a scene in a separated thread caused memory leaks in textures, 'cause textures can only be created, deleted and made resident and non resident in the same thread of the opengl context.

As Carlos already said: https://discord.com/channels/1029122111832338563/1030064402684194897/1130104514372960296

**This  was the cause for black textures in the scene, due to running out of vram so it coulnd't load any more textures**