### PR TITLE
fix: proper use of mutexes + scheduler fix

### DIFF
--- a/Source/Auxiliar/GameBuilder.cpp
+++ b/Source/Auxiliar/GameBuilder.cpp
@@ -103,7 +103,7 @@ void OnFileZipped(const FileZippedData& data)
 					maxMinutesToZip,
 					data.timeTaken.count());
 	}
-	std::scoped_lock(fileZippedDataMutex);
+	std::scoped_lock lock(fileZippedDataMutex);
 	lastFileZippedData = data;
 }
 
@@ -120,7 +120,7 @@ void CreateZip(const std::string& startingScene)
 
 	AddConfigToZip(startingScene);
 
-	std::scoped_lock(fileZippedDataMutex);
+	std::scoped_lock lock(fileZippedDataMutex);
 	lastFileZippedData.reset();
 
 	LOG_INFO("Done creating ZIP!");
@@ -183,7 +183,7 @@ bool Zipping()
 
 std::optional<FileZippedData> GetLastFileZippedData()
 {
-	std::scoped_lock(fileZippedDataMutex);
+	std::scoped_lock lock(fileZippedDataMutex);
 	return lastFileZippedData;
 }
 

--- a/Source/FileSystem/ModuleFileSystem.cpp
+++ b/Source/FileSystem/ModuleFileSystem.cpp
@@ -330,7 +330,7 @@ void ModuleFileSystem::AppendToZipFolder(const std::string& zipPath, const std::
 
 ConnectedCallback ModuleFileSystem::RegisterFileZippedCallback(FileZippedCallback&& callback)
 {
-	std::scoped_lock(callbacksMutex);
+	std::scoped_lock lock(callbacksMutex);
 	UID callbackUID = UniqueID::GenerateUID();
 	callbacks[callbackUID] = std::move(callback);
 	return ConnectedCallback(std::bind(&ModuleFileSystem::DeregisterFileZippedCallback, this, callbackUID));
@@ -338,7 +338,7 @@ ConnectedCallback ModuleFileSystem::RegisterFileZippedCallback(FileZippedCallbac
 
 void ModuleFileSystem::DeregisterFileZippedCallback(UID callbackUID)
 {
-	std::scoped_lock(callbacksMutex);
+	std::scoped_lock lock(callbacksMutex);
 	auto callbackToDelete = callbacks.find(callbackUID);
 	if (callbackToDelete != std::end(callbacks))
 	{
@@ -372,7 +372,7 @@ void ModuleFileSystem::ZipFolderRecursive(
 			std::chrono::duration<float> zipFileDuration = std::chrono::steady_clock::now() - zipFileStart;
 
 			FileZippedData fileZippedData{ itemPath, currentItem, std::move(zipFileDuration), rootPath, totalItems };
-			std::scoped_lock(callbacksMutex);
+			std::scoped_lock lock(callbacksMutex);
 			for (const auto& [_, callback] : callbacks)
 			{
 				callback(fileZippedData);

--- a/Source/FileSystem/ModuleFileSystem.h
+++ b/Source/FileSystem/ModuleFileSystem.h
@@ -63,5 +63,5 @@ private:
 	void DeregisterFileZippedCallback(UID callbackUID);
 
 	std::map<UID, FileZippedCallback> callbacks;
-	std::mutex callbacksMutex;
+	mutable std::mutex callbacksMutex;
 };

--- a/Source/Modules/ModuleScene.cpp
+++ b/Source/Modules/ModuleScene.cpp
@@ -201,7 +201,7 @@ bool ModuleScene::CleanUp()
 
 void ModuleScene::SetLoadedScene(std::unique_ptr<Scene> newScene)
 {
-	std::scoped_lock(loadedSceneMutex);
+	std::scoped_lock lock(loadedSceneMutex);
 	loadedScene = std::move(newScene);
 	selectedGameObject = loadedScene->GetRoot();
 }

--- a/Source/Modules/ModuleScene.h
+++ b/Source/Modules/ModuleScene.h
@@ -70,12 +70,14 @@ private:
 	// to store the tmp serialization of the Scene
 	rapidjson::Document tmpDoc;
 
-	std::mutex loadedSceneMutex;
+	// recursive because most graphic Components call GetScene in their destructors,
+	// which can be invoked during the call to SetScene (since the old scene would get destroyed)
+	mutable std::recursive_mutex loadedSceneMutex;
 };
 
 inline Scene* ModuleScene::GetLoadedScene() const
 {
-	std::scoped_lock(loadedSceneMutex);
+	std::scoped_lock lock(loadedSceneMutex);
 	return loadedScene.get();
 }
 


### PR DESCRIPTION
Couple of things fixed in this MR:
- Mutexes are now properly locked. Didn't realize that I forgot to give a name to a lock a few months back, and have been copy-pasting that mistake all over the place. Fixed that and the deadlocks that came up because of it.
- Scheduler::RunTasks stores a snapshot of the current state of the Schedulable queue. We retrieve the front of the queue as a reference `Schedulable& schedulable = ...`, but if the queue reallocates somewhere else (because ScheduleTask was called, for example), that memory can become invalid, which I'm almost positive is the cause of the original crash reported.