### PR TITLE
Fix: gameOver waits until health bar do the animation

### DIFF
--- a/Game/Scripts/SwitchPlayerManagerScript.cpp
+++ b/Game/Scripts/SwitchPlayerManagerScript.cpp
@@ -151,6 +151,11 @@ void SwitchPlayerManagerScript::SetIsSwitchAvailable(bool available)
 	secondPlayerHealthBar->Enable();
 }
 
+bool SwitchPlayerManagerScript::IsSwitchAvailable() const
+{
+	return isSwitchAvailable;
+}
+
 void SwitchPlayerManagerScript::VisualSwitchEffect()
 {
 	Scene* loadScene = App->GetModule<ModuleScene>()->GetLoadedScene();

--- a/Game/Scripts/SwitchPlayerManagerScript.h
+++ b/Game/Scripts/SwitchPlayerManagerScript.h
@@ -31,6 +31,7 @@ public:
 	void SwitchHealthBars();
 
 	void SetIsSwitchAvailable(bool available);
+	bool IsSwitchAvailable() const;
 
 	void VisualSwitchEffect();
 	GameObject* GetSecondPlayer() const;

--- a/Game/Scripts/UIGameManager.cpp
+++ b/Game/Scripts/UIGameManager.cpp
@@ -299,12 +299,12 @@ void UIGameManager::ModifySliderHealthValue(HealthSystem* healthSystemClass, Com
 
 	if (damageBack <= 0.0f && damage <= 0.0f)
 	{
-		componentSliderBack->ModifyCurrentValue(componentSliderBack->GetCurrentValue() + std::max(damageBack, -80.0f * deltaTime));
+		componentSliderBack->ModifyCurrentValue(componentSliderBack->GetCurrentValue() + std::max(damageBack, -25.0f * deltaTime));
 		componentSliderFront->ModifyCurrentValue(componentSliderFront->GetCurrentValue() + std::max(damage, -100.0f * deltaTime));
 	}
 	else
 	{
-		componentSliderBack->ModifyCurrentValue(componentSliderBack->GetCurrentValue() + std::min(damageBack, 80.0f * deltaTime));
+		componentSliderBack->ModifyCurrentValue(componentSliderBack->GetCurrentValue() + std::min(damageBack, 100.0f * deltaTime));
 		componentSliderFront->ModifyCurrentValue(componentSliderFront->GetCurrentValue() + std::min(damage, 100.0f * deltaTime));
 	}
 

--- a/Game/Scripts/UIGameManager.h
+++ b/Game/Scripts/UIGameManager.h
@@ -24,7 +24,7 @@ public:
 	void SetMenuIsOpen(bool menuState);
 	void MenuIsOpen();
 
-	void LoseGameState();
+	void LoseGameState(float deltaTime);
 	void WinGameState();
 
 	void EnableUIPwrUp(enum class PowerUpType pwrUp);
@@ -32,7 +32,8 @@ public:
 	void ActiveSliderUIPwrUP(float time);
 	void DisableUIPwrUP();
 
-	void ModifySliderHealthValue(HealthSystem* healthSystemClass, ComponentSlider* componentSliderFront, ComponentSlider* componentSliderBack);
+	void ModifySliderHealthValue(HealthSystem* healthSystemClass, ComponentSlider* componentSliderFront,
+								ComponentSlider* componentSliderBack, float deltaTime);
 	void SetMaxPowerUpTime(float maxPowerUpTime);
 	void InputMethodImg(bool input);
 
@@ -53,6 +54,7 @@ private:
 	float maxSliderValue = 0.0f;
 	float uiTime = 0.0f;
 	float currentInputTime = 0.0f;
+	float gameOverTimer = 0.0f;
 
 	int selectedPositon = -1;
 


### PR DESCRIPTION
GameOver screen now only appears when the UI health bar ends the full animation or certain time pass. With this you can proper see the death of the character.

The flow should be Bix death animation -> HealthBar goes down -> In case the HealthBar goes down is too short we have a auxiliar timer to wait a minimum time -> GameOver screen.