### PR TITLE
chore [UI]: add settings folder into ZIP when build

### DIFF
--- a/Source/FileSystem/ModuleFileSystem.cpp
+++ b/Source/FileSystem/ModuleFileSystem.cpp
@@ -300,6 +300,7 @@ void ModuleFileSystem::ZipLibFolder() const
 	zip_t* zip = zip_open("Assets.zip", ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
 	ZipFolder(zip, "Lib");
 	ZipFolder(zip, "WwiseProject");
+	ZipFolder(zip, "Settings");
 	zip_close(zip);
 }
 


### PR DESCRIPTION
Now the game settings are added into the asset folder when made a build