### PR TITLE
refactor: level 2 spawn from enemies

### DIFF
--- a/Game/Scripts/ActivationLogic.cpp
+++ b/Game/Scripts/ActivationLogic.cpp
@@ -27,7 +27,8 @@
 REGISTERCLASS(ActivationLogic);
 
 ActivationLogic::ActivationLogic() : Script(),
-componentAudio(nullptr), activeState(ActiveActions::INACTIVE), wasActivatedByPlayer(false)
+componentAudio(nullptr), activeState(ActiveActions::INACTIVE), wasActivatedByPlayer(false),
+wasActivatedByEnemy(false)
 {
 	REGISTER_FIELD(linkedHackZone, HackZoneScript*);
 	REGISTER_FIELD(interactWithEnemies, bool);
@@ -62,7 +63,8 @@ void ActivationLogic::Start()
 void ActivationLogic::Update(float deltaTime)
 {
 	if (!componentRigidBody->IsEnabled() 
-		&& App->GetModule<ModulePlayer>()->IsInCombat())
+		&& App->GetModule<ModulePlayer>()->IsInCombat() 
+		&& !wasActivatedByEnemy)
 	{
 		CloseDoor();
 	}
@@ -139,6 +141,7 @@ void ActivationLogic::OnCollisionExit(ComponentRigidBody* other)
 	{
 		if (other->GetOwner()->CompareTag("Enemy"))
 		{
+			wasActivatedByEnemy = false;
 			CloseDoor();
 		}
 	}
@@ -149,6 +152,7 @@ void ActivationLogic::NextInTheList()
 	elevator->SetBooked(true);
 	elevator->SetDisableInteractionsEnemies(enemiesWaiting[0],false, false, false);
 	enemiesWaiting.erase(enemiesWaiting.begin());
+	wasActivatedByEnemy = true;
 	OpenDoor();
 }
 

--- a/Game/Scripts/ActivationLogic.h
+++ b/Game/Scripts/ActivationLogic.h
@@ -53,4 +53,5 @@ private:
 	bool interactWithEnemies;
 
 	bool wasActivatedByPlayer;
+	bool wasActivatedByEnemy;
 };

--- a/Game/Scripts/EnemyVenomiteScript.cpp
+++ b/Game/Scripts/EnemyVenomiteScript.cpp
@@ -320,6 +320,7 @@ void EnemyVenomiteScript::ResetValues()
 	enemyDeathScript->ResetDespawnTimerAndEnableActions();
 	if (pathScript)
 	{
+		patrolScript->StopPatrol();
 		pathScript->Enable();
 		pathScript->ResetPath();
 	}

--- a/Game/Scripts/PathBehaviourScript.cpp
+++ b/Game/Scripts/PathBehaviourScript.cpp
@@ -78,8 +78,8 @@ void PathBehaviourScript::StartPath() const
 		enemyHealth->SetIsImmortal(true);
 	}
 	rigidBody->Enable();
-	rigidBody->SetUpMobility();
 	rigidBody->SetIsKinematic(false);
+	rigidBody->SetUpMobility();
 	agentComp->Disable();
 	agentComp->RemoveAgentFromCrowd();
 	aiMovement->SetMovementSpeed(agentVelocity);

--- a/Game/Scripts/PlayerMoveScript.cpp
+++ b/Game/Scripts/PlayerMoveScript.cpp
@@ -74,6 +74,10 @@ void PlayerMoveScript::PreUpdate(float deltaTime)
 		{
 			return;
 		}
+		else
+		{
+			btRigidbody->setAngularVelocity({ 0.0f,0.0f,0.0f });
+		}
 
 		if (isParalyzed)
 		{


### PR DESCRIPTION
- Now enemies have a path to the navmesh and then they patrol.
- Fix the error with the doors. When enemies try to pass the door is closed because the player is in combat mode.
- Now when an enemy is respawned we force stop patrolling in case that the enemy finishes in this state.