### PR TITLE
fix: Boss charge attack

### DIFF
--- a/Game/Scripts/BossChargeAttackScript.cpp
+++ b/Game/Scripts/BossChargeAttackScript.cpp
@@ -200,13 +200,13 @@ void BossChargeAttackScript::PrepareCharge() const
 	RotateToTarget(chargeThroughPosition);
 	rigidBody->SetKpTorque(5.0f);
 
-	/*float3 forward = transform->GetGlobalForward();
+	float3 forward = transform->GetGlobalForward();
 	forward.Normalize();
 
+
+
 	rigidBody->SetKpForce(0.5f);
-	rigidBody->SetPositionTarget(float3(forward.x * -5.0f + transform->GetGlobalPosition().x,
-										transform->GetGlobalPosition().y,
-										forward.z * -5.0f + transform->GetGlobalPosition().z));*/
+	rigidBody->SetPositionTarget(transform->GetGlobalPosition() - 5.0f*forward);
 }
 
 void BossChargeAttackScript::PerformChargeAttack()
@@ -219,9 +219,7 @@ void BossChargeAttackScript::PerformChargeAttack()
 	rigidBody->SetZRotationAxisBlocked(true);*/
 
 	rigidBody->SetKpForce(chargeForce);
-	rigidBody->SetPositionTarget(float3(forward.x * 50.0f,
-										transform->GetGlobalPosition().y,
-										forward.z * 50.0f));
+	rigidBody->SetPositionTarget(transform->GetGlobalPosition() + 150.0f *forward);
 
 	prepareChargeTime = prepareChargeMaxTime;
 	chargeState = ChargeState::CHARGING;

--- a/Game/Scripts/BossChargeAttackScript.cpp
+++ b/Game/Scripts/BossChargeAttackScript.cpp
@@ -200,13 +200,13 @@ void BossChargeAttackScript::PrepareCharge() const
 	RotateToTarget(chargeThroughPosition);
 	rigidBody->SetKpTorque(5.0f);
 
-	float3 forward = transform->GetGlobalForward();
+	/*float3 forward = transform->GetGlobalForward();
 	forward.Normalize();
 
 	rigidBody->SetKpForce(0.5f);
 	rigidBody->SetPositionTarget(float3(forward.x * -5.0f + transform->GetGlobalPosition().x,
 										transform->GetGlobalPosition().y,
-										forward.z * -5.0f + transform->GetGlobalPosition().z));
+										forward.z * -5.0f + transform->GetGlobalPosition().z));*/
 }
 
 void BossChargeAttackScript::PerformChargeAttack()

--- a/Game/Scripts/CameraBossControllerScript.cpp
+++ b/Game/Scripts/CameraBossControllerScript.cpp
@@ -72,9 +72,13 @@ void CameraBossControllerScript::PreUpdate(float deltaTime)
 		camera->RestoreKpRotation();
 
 		float3 sourceDirection = camera->GetCamera()->GetFrustum()->Front().Normalized();
-		float3 targetDirection = (playerTransform->GetGlobalPosition()
+
+		float3 directionalTargetVector = playerTransform->GetGlobalPosition()
 			+ defaultFocusOffsetVector
-			- camera->GetCamera()->GetPosition()).Normalized();
+			- camera->GetCamera()->GetPosition();
+		directionalTargetVector.y = 0.0f;
+
+		float3 targetDirection = directionalTargetVector.Normalized();
 
 		Quat orientationOffset = Quat::identity;
 


### PR DESCRIPTION
- Boss charge attack failed when Player was not moving. Inaccurate target point fixed.
- Avoided camera to rotate around X axis when Boss gets closer to Player.