### PR TITLE
fix: increased planar performance

### DIFF
--- a/Source/DataModels/Components/ComponentPlanarReflection.cpp
+++ b/Source/DataModels/Components/ComponentPlanarReflection.cpp
@@ -316,6 +316,17 @@ void ComponentPlanarReflection::InternalLoad(const Json& meta)
 	planeNormal.z = static_cast<float>(meta["planeNormal_z"]);
 
 	distortionAmount = static_cast<float>(meta["distortion_amount"]);
+
+	ComponentTransform* transform = GetOwner()->GetComponentInternal<ComponentTransform>();
+
+	float3 scaling = scale;
+
+	float3 translation = float3(-0.5f);
+
+	transform->TranslateLocalAABB(translation);
+	scaling.x *= 10;
+	scaling.z *= 10;
+	transform->ScaleLocalAABB(scaling);
 }
 
 void ComponentPlanarReflection::SignalEnable()


### PR DESCRIPTION
Fix an issue when loading a scene with planar reflections.
Level 2  have more stable fps.
Removed most of the planar.