### PR TITLE
chore: adapted gaussian blur

### DIFF
--- a/Source/Shaders/gaussian_blur.glsl
+++ b/Source/Shaders/gaussian_blur.glsl
@@ -30,5 +30,5 @@ void main()
 		result += textureLod(sourceTexture, TexCoord + blurDirection * OFFSETS[i] * invSize, mipmapSource) * WEIGHTS[i];
 	}
 
-	color = vec4(result.rgb, 1.0);
+	color = result;
 }


### PR DESCRIPTION
For how planar reflections work, the final color must use the alpha provided by the in-texture. This shouldn't affect any other texture that uses this method, like ssao, because all the textures are created with alpha = 1, unless you clean those values.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/Horizons-Games/Axolotl-Engine/assets/62140600/15668327-3356-4c84-aeee-318db5e90dbd)  | ![image](https://github.com/Horizons-Games/Axolotl-Engine/assets/62140600/11cde838-8499-4c2a-a5ef-450ced6958f7)  |
| ![image](https://github.com/Horizons-Games/Axolotl-Engine/assets/62140600/feb99434-b41c-4789-94e2-cc25dea7c8af)  | ![image](https://github.com/Horizons-Games/Axolotl-Engine/assets/62140600/c82cd632-be00-4176-a84d-f25d7c88388e)  |

SSAO texture:
![image](https://github.com/Horizons-Games/Axolotl-Engine/assets/62140600/8b55a771-d7bf-4c7f-a805-984921935948)
