### PR TITLE
fix: fade out with reflection

### DIFF
--- a/Game/Scripts/MeshEffect.cpp
+++ b/Game/Scripts/MeshEffect.cpp
@@ -159,11 +159,13 @@ void MeshEffect::EnableDisableMeshes(bool enable)
 	{
 		if (!enable)
 		{
+			mesh->SetReflective(true);
 			mesh->Disable();
 		}
 		else
 		{
 			mesh->Enable();
+			mesh->SetReflective(false);
 		}
 	}
 }


### PR DESCRIPTION
While the fade out effect was running, the "true" mesh was still reflected on the surface. Now only the fade out mesh is reflected.